### PR TITLE
Fix getPropertiesFromNamespace

### DIFF
--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3ConfigurationPropertyStore.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3ConfigurationPropertyStore.java
@@ -118,7 +118,7 @@ public class Etcd3ConfigurationPropertyStore implements IConfigurationPropertySt
 
     @Override
     public Map<String, String> getPropertiesFromNamespace(String namespace) {
-        ByteSequence bsNamespace = ByteSequence.from(namespace, UTF_8);
+        ByteSequence bsNamespace = ByteSequence.from(namespace + ".", UTF_8);
         GetOption option = GetOption.newBuilder()
                 .withSortField(GetOption.SortTarget.KEY)
                 .withSortOrder(GetOption.SortOrder.DESCEND)

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3ConfigurationPropertyStore.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3ConfigurationPropertyStore.java
@@ -118,15 +118,15 @@ public class Etcd3ConfigurationPropertyStore implements IConfigurationPropertySt
 
     @Override
     public Map<String, String> getPropertiesFromNamespace(String namespace) {
-        ByteSequence empty = ByteSequence.from("\0", UTF_8);
+        ByteSequence bsNamespace = ByteSequence.from(namespace, UTF_8);
         GetOption option = GetOption.newBuilder()
                 .withSortField(GetOption.SortTarget.KEY)
                 .withSortOrder(GetOption.SortOrder.DESCEND)
-                .withRange(empty)
+                .withRange(bsNamespace)
                 .withPrefix(ByteSequence.from(namespace, UTF_8))
                 .build();
 
-        CompletableFuture<GetResponse> futureResponse = client.getKVClient().get(empty, option);
+        CompletableFuture<GetResponse> futureResponse = client.getKVClient().get(bsNamespace, option);
         Map<String, String> results = new HashMap<>();
         try {
             GetResponse response = futureResponse.get();


### PR DESCRIPTION
Fixed `getPropertiesFromNamespace()` so that it returns properties **only** from the specified namespace, rather than all properties in a range from empty namespace to the given namespace.

Signed-off-by: Matthew Chivers <matthewchivers@outlook.com>