### PR TITLE
Fix dependency issues

### DIFF
--- a/galasa-eclipse-parent/dev.galasa.eclipse.feature/pom.xml
+++ b/galasa-eclipse-parent/dev.galasa.eclipse.feature/pom.xml
@@ -44,6 +44,11 @@
 			<artifactId>dev.galasa.ras.couchdb</artifactId>
 			<version>0.15.0-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<version>1.2</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/galasa-eclipse-parent/dev.galasa.eclipse/pom.xml
+++ b/galasa-eclipse-parent/dev.galasa.eclipse/pom.xml
@@ -31,7 +31,11 @@
 			<artifactId>gson</artifactId>
 			<version>2.7</version>
 		</dependency>
-
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<version>1.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/galasa-eclipse-parent/pom.xml
+++ b/galasa-eclipse-parent/pom.xml
@@ -78,12 +78,6 @@
 				<artifactId>dev.galasa.framework</artifactId>
 				<version>0.15.0-SNAPSHOT</version>
 			</dependency>
-			<dependency>
-				<groupId>commons-logging</groupId>
-				<artifactId>commons-logging</artifactId>
-				<version>1.2</version>
-				<scope>provided</scope>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/galasa-eclipse-parent/pom.xml
+++ b/galasa-eclipse-parent/pom.xml
@@ -78,6 +78,12 @@
 				<artifactId>dev.galasa.framework</artifactId>
 				<version>0.15.0-SNAPSHOT</version>
 			</dependency>
+			<dependency>
+				<groupId>commons-logging</groupId>
+				<artifactId>commons-logging</artifactId>
+				<version>1.2</version>
+				<scope>provided</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/galasa-extensions-parent/dev.galasa.jenkins/pom.xml
+++ b/galasa-extensions-parent/dev.galasa.jenkins/pom.xml
@@ -72,6 +72,12 @@
   		  <version>2.2.1</version>
   		  <scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.8.0</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<repositories>
 		<repository>

--- a/galasa-extensions-parent/dev.galasa.jenkins/pom.xml
+++ b/galasa-extensions-parent/dev.galasa.jenkins/pom.xml
@@ -76,7 +76,6 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.8.0</version>
-			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 	<repositories>


### PR DESCRIPTION
- Galasa-eclipse-parent was missing a dependency in the pom: `commons-logging`
- Galasa-extensions-parent was missing a dependency in the pom: `commons-io`