### PR TITLE
make sure unit tests get run on local builds

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -162,10 +162,17 @@ log_file=${LOGS_DIR}/${project}.txt
 info "Log will be placed at ${log_file}"
 
 if [[ "${build_type}" == "clean" ]]; then
-    goals="clean build publishToMavenLocal"
+    goals="clean build check publishToMavenLocal --no-build-cache "
 else
-    goals="build publishToMavenLocal"
+    goals="build check publishToMavenLocal"
 fi
+
+h2 "Removing .m2 artifacts"
+rm -fr ~/.m2/repository/dev/galasa/dev.galasa.cps.etcd
+rm -fr ~/.m2/repository/dev/galasa/dev.galasa.raw.couchdb
+success "OK"
+
+h2 "Building with gradle"
 
 cat << EOF 
 Using command:


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Gradle doesn't call unit tests unless you use the 'check' or 'test' targets. Fixed