### PR TITLE
Change isRelease build arg to isMainOrRelease

### DIFF
--- a/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -62,7 +62,7 @@ signing {
 }
 
 tasks.withType(Sign) {
-    onlyIf { isRelease.toBoolean() }
+    onlyIf { isMainOrRelease.toBoolean() }
 }
 
 publishing {

--- a/galasa-extensions-parent/gradle.properties
+++ b/galasa-extensions-parent/gradle.properties
@@ -1,4 +1,4 @@
-isRelease=false
+isMainOrRelease=false
 
 sourceMaven=https://repo.maven.apache.org/maven2/
 centralMaven=https://repo.maven.apache.org/maven2/


### PR DESCRIPTION
Updated the build arg isRelease to isMainORelease to reflect that signing should be completed for release builds, and now main builds also. Default value in the gradle.properties is still false though as this will be used in local builds.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>