### PR TITLE
fixing up couchdb wiring

### DIFF
--- a/galasa-extensions-parent/dev.galasa.cps.etcd/bnd.bnd
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/bnd.bnd
@@ -3,7 +3,13 @@ Bundle-Name: dev.galasa.cps.etcd
 Bundle-Description: Provides the CPS, DSS and Credential stores from a etcd3 server
 Bundle-License: https://www.eclipse.org/legal/epl-2.0
 Export-Package: !dev.galasa.cps.etcd.internal,dev.galasa.cps.etcd*
-Import-Package: dev.galasa,dev.galasa.cps.etcd,dev.galasa.framework.spi,dev.galasa.framework.spi.creds,javax.net.ssl,javax.security.cert
+Import-Package: \
+    dev.galasa,\
+    dev.galasa.cps.etcd,\
+    dev.galasa.framework.spi,\
+    dev.galasa.framework.spi.creds,\
+    javax.net.ssl,\
+    javax.security.cert
 Embed-Transitive: true
 Embed-Dependency: *;scope=compile|runtime
 -includeresource: gson-2.9.0.jar; lib:=true,\

--- a/galasa-extensions-parent/dev.galasa.cps.rest/bnd.bnd
+++ b/galasa-extensions-parent/dev.galasa.cps.rest/bnd.bnd
@@ -4,23 +4,21 @@ Bundle-Description: Provides access to the CPS via a remote REST endpoint over h
 Bundle-License: https://www.eclipse.org/legal/epl-2.0
 Export-Package: !dev.galasa.cps.rest.internal,dev.galasa.cps.rest*
 Import-Package: \
-com.google.gson,\
-dev.galasa,\
-dev.galasa.extensions.common.api,\
-dev.galasa.extensions.common.impl,\
-dev.galasa.framework.spi,\
-dev.galasa.framework.api.beans,\
-dev.galasa.framework.spi.utils,\
-javax.net.ssl,\
-javax.security.cert,\
-org.apache.commons.io,\
-org.apache.commons.logging,\
-org.apache.http,\
-org.apache.http.client.methods,\
-org.apache.http.client.utils,\
-org.apache.http.entity,\
-org.apache.http.impl.client,\
-org.apache.http.util
-Embed-Transitive: true
-Embed-Dependency: *;scope=compile|runtime
--fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=warning
+    com.google.gson,\
+    dev.galasa,\
+    dev.galasa.extensions.common.api,\
+    dev.galasa.extensions.common.impl,\
+    dev.galasa.framework.spi,\
+    dev.galasa.framework.api.beans,\
+    dev.galasa.framework.spi.utils,\
+    javax.net.ssl,\
+    javax.security.cert,\
+    org.apache.commons.io,\
+    org.apache.commons.logging,\
+    org.apache.http,\
+    org.apache.http.client.methods,\
+    org.apache.http.client.utils,\
+    org.apache.http.entity,\
+    org.apache.http.impl.client,\
+    org.apache.http.util
+

--- a/galasa-extensions-parent/dev.galasa.extensions.common/bnd.bnd
+++ b/galasa-extensions-parent/dev.galasa.extensions.common/bnd.bnd
@@ -4,12 +4,10 @@ Bundle-Description: Provides access to the CPS via a remote REST endpoint over h
 Bundle-License: https://www.eclipse.org/legal/epl-2.0
 Export-Package: dev.galasa.extensions.common.*
 Import-Package: \
-dev.galasa,\
-dev.galasa.framework.spi,\
-javax.net.ssl,\
-javax.security.cert,\
-org.apache.commons.logging,\
-org.apache.http.impl.client
-Embed-Transitive: true
-Embed-Dependency: *;scope=compile|runtime
--fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=warning
+    dev.galasa,\
+    dev.galasa.framework.spi,\
+    javax.net.ssl,\
+    javax.security.cert,\
+    org.apache.commons.logging,\
+    org.apache.http.impl.client
+    

--- a/release.yaml
+++ b/release.yaml
@@ -24,6 +24,17 @@ framework:
     obr: true
     isolated: true
     codecoverage: true
-    
+
+  - artifact: dev.galasa.cps.rest
+    version: 0.33.0
+    obr: true
+    isolated: true
+    codecoverage: true
+
+  - artifact: dev.galasa.extensions.common
+    version: 0.33.0
+    obr: true
+    isolated: true
+    codecoverage: true 
 
     


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why change ?
The couchdb extension wasn't able to start because the common bundle wasn't included in the OBR

See 
[Local test run to be able to use remote CPS #1813](https://github.com/galasa-dev/projectmanagement/issues/1813)

# What changed
- the couchdb OSGi wiring was broken by not adding the common bundles in.
- transitive dependencies were being included in the rest cps bundle.

