### PR TITLE
CPS interface adds some more exceptions

### DIFF
--- a/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa etcd3 for CPS, DSS and Credentials - Provides the CPS, DSS and Credential stores from a etcd3 server'
 
-version = '0.31.0'
+version = '0.33.0'
 
 dependencies {
     implementation ('io.etcd:jetcd-core:0.5.9')

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3ConfigurationPropertyStore.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3ConfigurationPropertyStore.java
@@ -130,7 +130,7 @@ public class Etcd3ConfigurationPropertyStore implements IConfigurationPropertySt
     }
 
     @Override
-    public Map<String, String> getPropertiesFromNamespace(String namespace) {
+    public Map<String, String> getPropertiesFromNamespace(String namespace) throws ConfigurationPropertyStoreException {
         ByteSequence bsNamespace = ByteSequence.from(namespace + ".", UTF_8);
         GetOption option = GetOption.newBuilder()
                 .withSortField(GetOption.SortTarget.KEY)
@@ -154,7 +154,7 @@ public class Etcd3ConfigurationPropertyStore implements IConfigurationPropertySt
     }
 
     @Override
-    public List<String> getNamespaces() {
+    public List<String> getNamespaces() throws ConfigurationPropertyStoreException {
         ByteSequence empty = ByteSequence.from("\0", UTF_8);
         GetOption option = GetOption.newBuilder()
                 .withSortField(GetOption.SortTarget.KEY)

--- a/galasa-extensions-parent/dev.galasa.cps.rest/src/main/java/dev/galasa/cps/rest/RestCPS.java
+++ b/galasa-extensions-parent/dev.galasa.cps.rest/src/main/java/dev/galasa/cps/rest/RestCPS.java
@@ -401,33 +401,28 @@ public class RestCPS implements IConfigurationPropertyStore {
      * 
      * @param namespace The namespace we want to get the property from.
      * @return The properties returned.
+     * @throws ConfigurationPropertyStoreException 
      */
     @Override
-    public Map<String,String> getPropertiesFromNamespace(String namespace) {
+    public Map<String,String> getPropertiesFromNamespace(String namespace) throws ConfigurationPropertyStoreException {
 
         Map<String,String> results = new HashMap<String,String>();
 
-        // TODO: The interface is wrong. It should allow throwing of an exception.
-        try {
-            URI targetUri = calculateQueryPropertyUri(namespace, NULL_PREFIX, NULL_SUFFIX, NULL_INFIX);
-            HttpGet req = constructGetRequest(targetUri, this.jwt);
+        URI targetUri = calculateQueryPropertyUri(namespace, NULL_PREFIX, NULL_SUFFIX, NULL_INFIX);
+        HttpGet req = constructGetRequest(targetUri, this.jwt);
 
-            // Note: The response is always closed properly.
-            try ( CloseableHttpResponse response = (CloseableHttpResponse) this.apiClient.execute(req) ) {
+        // Note: The response is always closed properly.
+        try ( CloseableHttpResponse response = (CloseableHttpResponse) this.apiClient.execute(req) ) {
 
-                checkResponseHttpCode(response, ERROR_GALASA_REST_CALL_TO_GET_ALL_CPS_PROPERTIES_NON_OK_STATUS, targetUri);
-                GalasaProperty[] properties = extractPropertiesFromPayload(response, targetUri);
-                results = propertiesToMap(properties);
+            checkResponseHttpCode(response, ERROR_GALASA_REST_CALL_TO_GET_ALL_CPS_PROPERTIES_NON_OK_STATUS, targetUri);
+            GalasaProperty[] properties = extractPropertiesFromPayload(response, targetUri);
+            results = propertiesToMap(properties);
 
-            } catch(IOException ioEx) {
-                String msg = ERROR_GALASA_REST_CALL_TO_GET_CPS_PROPERTIES_FAILED.getMessage(targetUri.toString(),ioEx.getMessage());
-                throw new ConfigurationPropertyStoreException(msg,ioEx);
-            }
-
-        } catch ( ConfigurationPropertyStoreException ex) {
-            // TODO: Temporarily turn the exception into a runtime exception... as that can be used and still maintain the interface.
-            throw new RuntimeException(ex);
+        } catch(IOException ioEx) {
+            String msg = ERROR_GALASA_REST_CALL_TO_GET_CPS_PROPERTIES_FAILED.getMessage(targetUri.toString(),ioEx.getMessage());
+            throw new ConfigurationPropertyStoreException(msg,ioEx);
         }
+
         return results;
     }
 
@@ -457,30 +452,26 @@ public class RestCPS implements IConfigurationPropertyStore {
      * Return all Namespaces for the framework property file
      * 
      * @return - List of namespaces
+     * @throws ConfigurationPropertyStoreException 
      */
     @Override
-    public List<String> getNamespaces() {
+    public List<String> getNamespaces() throws ConfigurationPropertyStoreException {
         List<String> results = new ArrayList<String>();
 
-        // TODO: The interface is wrong. It should allow throwing of an exception.
-        try {
-            URI targetUri = calculateQueryNamespaceUri();
-            HttpGet req = constructGetRequest(targetUri, this.jwt);
+        URI targetUri = calculateQueryNamespaceUri();
+        HttpGet req = constructGetRequest(targetUri, this.jwt);
 
-            // Note: The response is always closed properly.
-            try ( CloseableHttpResponse response = (CloseableHttpResponse) this.apiClient.execute(req) ) {
+        // Note: The response is always closed properly.
+        try ( CloseableHttpResponse response = (CloseableHttpResponse) this.apiClient.execute(req) ) {
 
-                checkResponseHttpCode(response, ERROR_GALASA_REST_CALL_TO_GET_ALL_CPS_NAMESPACES_NON_OK_STATUS, targetUri);
-                results = extractNamespacesFromPayload(response, targetUri);
+            checkResponseHttpCode(response, ERROR_GALASA_REST_CALL_TO_GET_ALL_CPS_NAMESPACES_NON_OK_STATUS, targetUri);
+            results = extractNamespacesFromPayload(response, targetUri);
 
-            } catch(IOException ioEx) {
-                String msg = ERROR_GALASA_REST_CALL_TO_GET_CPS_NAMESPACES_FAILED.getMessage(targetUri.toString(),ioEx.getMessage());
-                throw new ConfigurationPropertyStoreException(msg,ioEx);
-            } 
-        } catch ( ConfigurationPropertyStoreException ex) {
-            // TODO: Temporarily turn the exception into a runtime exception... as that can be used and still maintain the interface.
-            throw new RuntimeException(ex);
-        }
+        } catch(IOException ioEx) {
+            String msg = ERROR_GALASA_REST_CALL_TO_GET_CPS_NAMESPACES_FAILED.getMessage(targetUri.toString(),ioEx.getMessage());
+            throw new ConfigurationPropertyStoreException(msg,ioEx);
+        } 
+
         return results;
     }
 

--- a/release.yaml
+++ b/release.yaml
@@ -20,7 +20,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.cps.etcd
-    version: 0.31.0
+    version: 0.33.0
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Local test run to be able to use remote CPS
[#1813](https://github.com/galasa-dev/projectmanagement/issues/1813)

The CPS interface should have had some exceptions possibly throwing failures on 
getNamespaces() and shutdown(). It's possible something will go wrong with these and there is no other way of reporting a failure with them.

Adding extra throws clauses and fixing all the implementations to be able to throw them also.