### PR TITLE
updated commons-io to 2.16.1

### DIFF
--- a/galasa-extensions-parent/dev.galasa.cps.rest/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.cps.rest/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa CPS access over http - Provides the CPS stores via the public REST interface over http'
 
-version = '0.33.0'
+version = '0.34.0'
 
 dependencies {
     
@@ -15,7 +15,7 @@ dependencies {
     }
     implementation ('dev.galasa:dev.galasa.framework.api.beans:0.33.0')
     implementation (project(':dev.galasa.extensions.common'))
-    implementation 'commons-io:commons-io:2.9.0'
+    implementation 'commons-io:commons-io:2.16.1'
     // https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
 

--- a/release.yaml
+++ b/release.yaml
@@ -26,7 +26,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.cps.rest
-    version: 0.33.0
+    version: 0.34.0
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
## Why?

This change is needed in order to resolve the vulnerabilities within the commons-compress package at version 1.21. to resolve this the package needs to be bumped up to version 1.26.0 along with it's dependencies.