### PR TITLE
updated version of dev.galasa package to 0.34.0

### DIFF
--- a/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
+++ b/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation 'dev.galasa:dev.galasa.framework:0.33.0'
-    implementation 'dev.galasa:dev.galasa:0.21.0'
+    implementation 'dev.galasa:dev.galasa:0.34.0'
 
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'org.osgi:org.osgi.core:6.0.0'


### PR DESCRIPTION
## Why?

Following the bumping of dev.galasa to a new version, the extensions need to point to the same version in order to pick up the latest changes