### PR TITLE
Use ApiServerInitialisation for CouchDB auth extension

### DIFF
--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreRegistration.java
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStoreRegistration.java
@@ -19,7 +19,7 @@ import dev.galasa.extensions.common.impl.HttpClientFactoryImpl;
 import dev.galasa.extensions.common.impl.HttpRequestFactoryImpl;
 import dev.galasa.extensions.common.api.HttpRequestFactory;
 import dev.galasa.extensions.common.impl.LogFactoryImpl;
-import dev.galasa.framework.spi.IFrameworkInitialisation;
+import dev.galasa.framework.spi.IApiServerInitialisation;
 import dev.galasa.framework.spi.SystemEnvironment;
 import dev.galasa.framework.spi.auth.IAuthStoreRegistration;
 import dev.galasa.framework.spi.utils.SystemTimeService;
@@ -53,18 +53,18 @@ public class CouchdbAuthStoreRegistration implements IAuthStoreRegistration {
      * This method checks that the auth store is a remote URL reference, and if true
      * registers a new couchdb auth store as the only auth store.
      *
-     * @param frameworkInitialisation Parameters this extension can use to to
+     * @param apiServerInitialisation Parameters this extension can use to to
      *                                initialise itself.
      * @throws AuthStoreException if there was a problem accessing the auth store.
      */
     @Override
-    public void initialise(IFrameworkInitialisation frameworkInitialisation) throws AuthStoreException {
+    public void initialise(IApiServerInitialisation apiServerInitialisation) throws AuthStoreException {
 
-        URI authStoreUri = frameworkInitialisation.getAuthStoreUri();
+        URI authStoreUri = apiServerInitialisation.getAuthStoreUri();
 
         if (isUriReferringToThisExtension(authStoreUri)) {
             try {
-                frameworkInitialisation.registerAuthStore(
+                apiServerInitialisation.registerAuthStore(
                     new CouchdbAuthStore(
                         authStoreUri,
                         httpClientFactory,

--- a/galasa-extensions-parent/dev.galasa.extensions.mocks/src/main/java/dev/galasa/extensions/mocks/MockFrameworkInitialisation.java
+++ b/galasa-extensions-parent/dev.galasa.extensions.mocks/src/main/java/dev/galasa/extensions/mocks/MockFrameworkInitialisation.java
@@ -11,13 +11,13 @@ import dev.galasa.framework.spi.CertificateStoreException;
 import dev.galasa.framework.spi.ConfidentialTextException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.EventsException;
+import dev.galasa.framework.spi.IApiServerInitialisation;
 import dev.galasa.framework.spi.ICertificateStoreService;
 import dev.galasa.framework.spi.IConfidentialTextService;
 import dev.galasa.framework.spi.IConfigurationPropertyStore;
 import dev.galasa.framework.spi.IDynamicStatusStore;
 import dev.galasa.framework.spi.IEventsService;
 import dev.galasa.framework.spi.IFramework;
-import dev.galasa.framework.spi.IFrameworkInitialisation;
 import dev.galasa.framework.spi.IResultArchiveStoreService;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.auth.IAuthStore;
@@ -28,7 +28,7 @@ import dev.galasa.framework.spi.creds.ICredentialsStore;
 import java.net.URI;
 import java.util.*;
 
-public class MockFrameworkInitialisation implements IFrameworkInitialisation {
+public class MockFrameworkInitialisation implements IApiServerInitialisation {
 
     protected URI authStoreUri;
     protected URI cpsBootstrapUri;


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1864
Related to changes in https://github.com/galasa-dev/framework/pull/553

Note: Builds for this PR will fail until the above PR is merged.

## Changes
- Updated the CouchDB auth store registration to use the new API server initialisation interface as it will only be initialised when starting the API server