### PR TITLE
Bump gson to 2.10.1 in etcd extension

### DIFF
--- a/galasa-extensions-parent/dev.galasa.cps.etcd/bnd.bnd
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/bnd.bnd
@@ -12,7 +12,7 @@ Import-Package: \
     javax.security.cert
 Embed-Transitive: true
 Embed-Dependency: *;scope=compile|runtime
--includeresource: gson-2.9.0.jar; lib:=true,\
+-includeresource: gson-2.10.1.jar; lib:=true,\
     jetcd-core-0.5.9.jar; lib:=true,\
     jetcd-common-0.5.9.jar; lib:=true,\
     grpc-core-1.39.0.jar; lib:=true,\

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
@@ -5,13 +5,13 @@ plugins {
 
 description = 'Galasa etcd3 for CPS, DSS and Credentials - Provides the CPS, DSS and Credential stores from a etcd3 server'
 
-version = '0.33.0'
+version = '0.34.0'
 
 dependencies {
     implementation ('io.etcd:jetcd-core:0.5.9')
     
     // Not required for compile,  but required to force the download of the jars to embed by bnd
-    implementation ('com.google.code.gson:gson:2.9.0') {
+    implementation ('com.google.code.gson:gson:2.10.1') {
        force = true
     }
     implementation ('org.codehaus.mojo:animal-sniffer-annotations:1.19')

--- a/release.yaml
+++ b/release.yaml
@@ -26,7 +26,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.cps.etcd
-    version: 0.33.0
+    version: 0.34.0
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
## Why?
Related to https://github.com/galasa-dev/projectmanagement/issues/1898

This brings the gson dependency in line with the rest of the Galasa codebase, which currently uses gson 2.10.1.