### PR TITLE
Upgrade versions to 0.34.1

### DIFF
--- a/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
+++ b/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'dev.galasa:dev.galasa.framework:0.34.0'
+    implementation 'dev.galasa:dev.galasa.framework:0.34.1'
     implementation 'dev.galasa:dev.galasa:0.34.0'
 
     implementation 'commons-logging:commons-logging:1.2'

--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 description = 'Galasa Authentication - CouchDB'
 
-version = '0.34.0'
+version = '0.34.1'
 
 configurations {
     implementation.transitive = false

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa etcd3 for CPS, DSS and Credentials - Provides the CPS, DSS and Credential stores from a etcd3 server'
 
-version = '0.34.0'
+version = '0.34.1'
 
 dependencies {
     implementation ('io.etcd:jetcd-core:0.5.9')

--- a/galasa-extensions-parent/dev.galasa.cps.rest/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.cps.rest/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa CPS access over http - Provides the CPS stores via the public REST interface over http'
 
-version = '0.34.0'
+version = '0.34.1'
 
 dependencies {
 

--- a/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa CPS access over http - Provides the CPS stores via the public REST interface over http'
 
-version = '0.34.0'
+version = '0.34.1'
 
 dependencies {
     implementation ('org.apache.httpcomponents:httpclient-osgi:4.5.13')

--- a/galasa-extensions-parent/dev.galasa.extensions.mocks/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.extensions.mocks/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 description = 'Galasa extensions mocks used for tests'
 
-version = '0.34.0'
+version = '0.34.1'
 
 configurations {
     implementation.transitive = false
@@ -14,7 +14,7 @@ dependencies {
     implementation ('org.apache.httpcomponents:httpclient-osgi:4.5.13')
     implementation ('org.apache.httpcomponents:httpcore-osgi:4.4.14')
     implementation ('com.google.code.gson:gson:2.10.1')
-    implementation ('dev.galasa:dev.galasa.framework: 0.33.0')
+    implementation ('dev.galasa:dev.galasa.framework:0.34.1')
     implementation ('junit:junit:4.13.1')
     implementation ('org.assertj:assertj-core:3.16.1')
     implementation (project(':dev.galasa.extensions.common'))

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 description = 'Galasa RAS - CouchDB'
 
-version = '0.34.0'
+version = '0.34.1'
 
 configurations {
     implementation.transitive = false

--- a/release.yaml
+++ b/release.yaml
@@ -14,31 +14,31 @@ framework:
   bundles:
 
   - artifact: dev.galasa.auth.couchdb
-    version: 0.34.0
+    version: 0.34.1
     obr: true
     isolated: true
     codecoverage: true
 
   - artifact: dev.galasa.ras.couchdb
-    version: 0.34.0
+    version: 0.34.1
     obr: true
     isolated: true
     codecoverage: true
 
   - artifact: dev.galasa.cps.etcd
-    version: 0.34.0
+    version: 0.34.1
     obr: true
     isolated: true
     codecoverage: true
 
   - artifact: dev.galasa.cps.rest
-    version: 0.34.0
+    version: 0.34.1
     obr: true
     isolated: true
     codecoverage: true
 
   - artifact: dev.galasa.extensions.common
-    version: 0.34.0
+    version: 0.34.1
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
### Why?
Upgrade version of dev.galasa.framework to 0.34.1 for patch release. In turn upgrade the Galasa extensions that had that dependency (all of them).