### PR TITLE
upgraded java version gradle is compiling to

### DIFF
--- a/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -6,8 +6,8 @@ plugins {
 
 group = 'dev.galasa'
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 21
+targetCompatibility = 21
 
 java {
     withJavadocJar()


### PR DESCRIPTION
# Why
Java is outdated on this branch, upgrading to latest version, relates to: https://github.com/galasa-dev/projectmanagement/issues/1823