### PR TITLE
Only register KafkaEventsService if remote run

### DIFF
--- a/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventsServiceRegistration.java
+++ b/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventsServiceRegistration.java
@@ -5,6 +5,8 @@
  */
 package dev.galasa.events.kafka.internal;
 
+import java.net.URI;
+
 import javax.validation.constraints.NotNull;
 
 import org.osgi.service.component.annotations.Component;
@@ -27,13 +29,18 @@ public class KafkaEventsServiceRegistration implements IEventsServiceRegistratio
 
         try {
 
-            IFramework framework = frameworkInitialisation.getFramework();
+            URI cps = frameworkInitialisation.getBootstrapConfigurationPropertyStore();
 
-            SystemEnvironment env = new SystemEnvironment();
-            KafkaEventProducerFactory producerFactory = new KafkaEventProducerFactory(env);
-            IConfigurationPropertyStoreService cpsService = framework.getConfigurationPropertyService(NAMESPACE);
+            // If the CPS is ETCD, then register this version of the EventsService
+            if (cps.getScheme().equals("etcd")) {
+                IFramework framework = frameworkInitialisation.getFramework();
 
-            frameworkInitialisation.registerEventsService(new KafkaEventsService(cpsService, producerFactory));
+                SystemEnvironment env = new SystemEnvironment();
+                KafkaEventProducerFactory producerFactory = new KafkaEventProducerFactory(env);
+                IConfigurationPropertyStoreService cpsService = framework.getConfigurationPropertyService(NAMESPACE);
+
+                frameworkInitialisation.registerEventsService(new KafkaEventsService(cpsService, producerFactory));
+            }
 
         } catch (Exception e) {
             throw new KafkaException("Unable to register the Kafka Events Service", e);

--- a/galasa-extensions-parent/dev.galasa.events.kafka/src/test/java/dev/galasa/events/kafka/TestKafkaEventsServiceRegistration.java
+++ b/galasa-extensions-parent/dev.galasa.events.kafka/src/test/java/dev/galasa/events/kafka/TestKafkaEventsServiceRegistration.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.net.URI;
 import java.util.List;
 
 import dev.galasa.events.kafka.internal.KafkaEventsService;
@@ -24,11 +25,12 @@ public class TestKafkaEventsServiceRegistration {
     }
 
     @Test
-    public void TestCanInitialiseARegistrationOK() throws Exception {
+    public void TestWhenRemoteRunCanInitialiseARegistrationOK() throws Exception {
         // Given...
         KafkaEventsServiceRegistration registration = new KafkaEventsServiceRegistration();
 
-        MockFrameworkInitialisation mockFrameworkInit = new MockFrameworkInitialisation();
+        URI uri = new URI("etcd://my.server/api");
+        MockFrameworkInitialisation mockFrameworkInit = new MockFrameworkInitialisation(uri);
 
         // When...
         registration.initialise(mockFrameworkInit);
@@ -37,6 +39,22 @@ public class TestKafkaEventsServiceRegistration {
         List<IEventsService> eventsServices = mockFrameworkInit.getRegisteredEventsServices();
         assertThat(eventsServices).isNotNull().hasSize(1);
         assertThat(eventsServices.get(0)).isInstanceOf(KafkaEventsService.class);
+    }
+
+    @Test
+    public void TestWhenLocalRunDoesNotInitialiseRegistration() throws Exception {
+        // Given...
+        KafkaEventsServiceRegistration registration = new KafkaEventsServiceRegistration();
+
+        URI uri = new URI("notetcd://my.server/api");
+        MockFrameworkInitialisation mockFrameworkInit = new MockFrameworkInitialisation(uri);
+
+        // When...
+        registration.initialise(mockFrameworkInit);
+
+        // Then...
+        List<IEventsService> eventsServices = mockFrameworkInit.getRegisteredEventsServices();
+        assertThat(eventsServices).isNotNull().hasSize(0);
     }
     
 }


### PR DESCRIPTION
Check the CPS URI scheme and only register if the CPS is an ETCD. 