### PR TITLE
Iss1914 - Fix Kakfa authentication failure

### DIFF
--- a/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventProducerFactory.java
+++ b/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventProducerFactory.java
@@ -16,10 +16,10 @@ import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 
 public class KafkaEventProducerFactory implements IEventProducerFactory {
 
-    private String authToken;
+    private final String AUTH_TOKEN;
 
     public KafkaEventProducerFactory(String authToken) {
-        this.authToken = authToken;
+        this.AUTH_TOKEN = authToken;
     }
 
     public KafkaEventProducer createProducer(Properties properties, String topic) throws EventsException {
@@ -40,7 +40,7 @@ public class KafkaEventProducerFactory implements IEventProducerFactory {
             properties.put("topic", topic);
             properties.put("key.serializer", StringSerializer.class.getName());
             properties.put("value.serializer", StringSerializer.class.getName());
-            properties.put("sasl.jaas.config", PlainLoginModule.class.getName() + " required username=\"token\" password=\"" + this.authToken + "\";");
+            properties.put("sasl.jaas.config", PlainLoginModule.class.getName() + " required username=\"token\" password=\"" + this.AUTH_TOKEN + "\";");
             properties.put("security.protocol", "SASL_SSL");
             properties.put("sasl.mechanism", "PLAIN");
             properties.put("ssl.protocol", "TLSv1.2");

--- a/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventProducerFactory.java
+++ b/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventProducerFactory.java
@@ -13,16 +13,13 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.EventsException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
-import dev.galasa.framework.spi.SystemEnvironment;
 
 public class KafkaEventProducerFactory implements IEventProducerFactory {
 
-    private final String TOKEN = "GALASA_EVENT_STREAMS_TOKEN";
+    private String authToken;
 
-    private SystemEnvironment env;
-
-    public KafkaEventProducerFactory(SystemEnvironment env) {
-        this.env = env;
+    public KafkaEventProducerFactory(String authToken) {
+        this.authToken = authToken;
     }
 
     public KafkaEventProducer createProducer(Properties properties, String topic) throws EventsException {
@@ -43,7 +40,7 @@ public class KafkaEventProducerFactory implements IEventProducerFactory {
             properties.put("topic", topic);
             properties.put("key.serializer", StringSerializer.class.getName());
             properties.put("value.serializer", StringSerializer.class.getName());
-            properties.put("sasl.jaas.config", PlainLoginModule.class.getName() + " required username=\"token\" password=\"" + this.env.getenv(TOKEN) + "\";");
+            properties.put("sasl.jaas.config", PlainLoginModule.class.getName() + " required username=\"token\" password=\"" + this.authToken + "\";");
             properties.put("security.protocol", "SASL_SSL");
             properties.put("sasl.mechanism", "PLAIN");
             properties.put("ssl.protocol", "TLSv1.2");

--- a/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventsServiceRegistration.java
+++ b/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventsServiceRegistration.java
@@ -23,7 +23,7 @@ public class KafkaEventsServiceRegistration implements IEventsServiceRegistratio
 
     private final String NAMESPACE = "kafka";
 
-    private final String TOKEN = "GALASA_EVENT_STREAMS_TOKEN";
+    private final String TOKEN_NAME = "GALASA_EVENT_STREAMS_TOKEN";
     
     @Override
     public void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation)
@@ -38,7 +38,7 @@ public class KafkaEventsServiceRegistration implements IEventsServiceRegistratio
                 IFramework framework = frameworkInitialisation.getFramework();
 
                 SystemEnvironment env = new SystemEnvironment();
-                String authToken = env.getenv(TOKEN);
+                String authToken = env.getenv(TOKEN_NAME);
                 KafkaEventProducerFactory producerFactory = new KafkaEventProducerFactory(authToken);
                 IConfigurationPropertyStoreService cpsService = framework.getConfigurationPropertyService(NAMESPACE);
 

--- a/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventsServiceRegistration.java
+++ b/galasa-extensions-parent/dev.galasa.events.kafka/src/main/java/dev/galasa/events/kafka/internal/KafkaEventsServiceRegistration.java
@@ -22,6 +22,8 @@ import dev.galasa.framework.spi.SystemEnvironment;
 public class KafkaEventsServiceRegistration implements IEventsServiceRegistration {
 
     private final String NAMESPACE = "kafka";
+
+    private final String TOKEN = "GALASA_EVENT_STREAMS_TOKEN";
     
     @Override
     public void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation)
@@ -36,7 +38,8 @@ public class KafkaEventsServiceRegistration implements IEventsServiceRegistratio
                 IFramework framework = frameworkInitialisation.getFramework();
 
                 SystemEnvironment env = new SystemEnvironment();
-                KafkaEventProducerFactory producerFactory = new KafkaEventProducerFactory(env);
+                String authToken = env.getenv(TOKEN);
+                KafkaEventProducerFactory producerFactory = new KafkaEventProducerFactory(authToken);
                 IConfigurationPropertyStoreService cpsService = framework.getConfigurationPropertyService(NAMESPACE);
 
                 frameworkInitialisation.registerEventsService(new KafkaEventsService(cpsService, producerFactory));


### PR DESCRIPTION
### Why?

This aims to solve the bug where authentication to the event streams instance the Kakfa extension is configured to connect to is failing. I believe the SystemEnvironment is being changed or reset later in the stack so extracting the token immediately, the same as the CouchDB extension does, should hopefully fix this.