### PR TITLE
Auto-generate release.yaml from subproject contents and use it in local builds

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -245,8 +245,24 @@ function check_secrets {
     success "secrets audit complete"
 }
 
+function update_release_yaml {
+    h2 "Updating release.yaml"
+
+    # After running 'gradle build', a release.yaml file should have been automatically generated
+    generated_release_yaml="${BASEDIR}/galasa-extensions-parent/build/release.yaml"
+    current_release_yaml="${BASEDIR}/release.yaml"
+
+    if [[ -f ${generated_release_yaml} ]]; then
+        cp ${generated_release_yaml} ${current_release_yaml}
+        success "Updated release.yaml OK"
+    else
+        warn "Failed to automatically generate release.yaml, please ensure any changed bundles have had their versions updated in ${current_release_yaml}"
+    fi
+}
+
 clean_maven_repo
 build_with_gradle
+update_release_yaml
 displayCouchDbCodeCoverage
 displayKafkaCodeCoverage
 check_secrets

--- a/galasa-extensions-parent/build.gradle
+++ b/galasa-extensions-parent/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'biz.aQute.bnd.builder' version '5.3.0' apply false
     id 'dev.galasa.githash' version '0.15.0' apply false
+    id 'maven-publish'
 }
 
 version = '0.15.0'
@@ -12,7 +13,196 @@ task clean {
    }
 }
 
+//---------------------------------------------------------------
+// We need to gather the release and packaging metadata from each
+// sub-project, to generate a release.yaml document which can act
+// as a manifest for this component.
+//
+// The OSGi bundles in the extensions project are all in the
+// 'framework' group.
+//
+// Each module is examined, and contributes it's metadata to an
+// overall manifest file, ready to be published to a maven
+// repository.
+//
+// At a later time, the OBR project will draw down the manifest
+// and use it to build the uber-obr.
+//---------------------------------------------------------------
+configurations {
+    release_metadata
+}
+
+def overallManifestFilePath = "$buildDir/release.yaml"
+def overallHeader = """#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# -----------------------------------------------------------
+#
+#                         WARNING
+#
+# This file is periodically re-generated from the contents of
+# the repository, so don't make changes here manually please.
+# -----------------------------------------------------------
+
+
+apiVersion: galasa.dev/v1alpha
+kind: Release
+metadata:
+  name: galasa-release
+
+framework:
+  bundles:
+"""
+
+//----------------------------------------------------------
+// Flushes any existing content on the specified path, and
+// creates a new file, containing the header text.
+//----------------------------------------------------------
+def prepareGeneratedFile(path, header) {
+    // Make sure the manifest file is clean, and exists.
+    def manifestFile = new File(path)
+    if (manifestFile.exists()) {
+        // File exists, delete it and create a new one.
+        manifestFile.delete()
+    }
+    manifestFile.createNewFile()
+
+    // Add the header to the manifest file
+    manifestFile.append(header)
+}
+
+//----------------------------------------------------------
+// Allow each subproject to contribute to one of the manifest
+// collections.
+//----------------------------------------------------------
+task buildReleaseYaml() {
+    println 'Building the release.yaml file...'
+
+    // During execution phase, make sure the file exists.
+    doFirst {
+        // Make sure the build directory exists.
+        if (!buildDir.exists()) {
+            buildDir.mkdirs()
+        }
+
+        prepareGeneratedFile(overallManifestFilePath, overallHeader)
+    }
+
+    subprojects {
+        ext {
+            // the property that should be overridden in suproject's build.gradle
+            // Each sub-project will set the values...
+            projectName = ''
+            includeInOBR = ''
+            includeInMVP = ''
+            includeInBOM = ''
+            includeInJavadoc = ''
+            includeInIsolated = ''
+            includeInCodeCoverage = ''
+        }
+
+        afterEvaluate {
+            doLast {
+                // Some projects don't have a version property... as they are parent projects mostly.
+                if (version != 'unspecified') {
+                    if (projectName == '') {
+                        throw new Exception("Project has no name.")
+                    }
+
+                    def f = new File(overallManifestFilePath)
+                    f.append("\n\n  - artifact: $projectName")
+                    f.append("\n    version: $version")
+                    if (includeInOBR != '') {
+                        f.append("\n    obr:          $includeInOBR")
+                    }
+                    if (includeInMVP != '') {
+                        f.append("\n    mvp:          $includeInMVP")
+                    }
+                    if (includeInBOM != '') {
+                        f.append("\n    bom:          $includeInBOM")
+                    }
+                    if (includeInJavadoc != '') {
+                        f.append("\n    javadoc:      $includeInJavadoc")
+                    }
+                    if (includeInIsolated != '') {
+                        f.append("\n    isolated:     $includeInIsolated")
+                    }
+                    if (includeInCodeCoverage != '') {
+                        f.append("\n    codecoverage: $includeInCodeCoverage")
+                    }
+
+                }
+            }
+        }
+    }
+}
+
+// Declare that the uber-manifest release.yaml file exists, and how to build it.
+def myReleaseYaml = artifacts.add('release_metadata', file(overallManifestFilePath)) {
+    builtBy 'buildReleaseYaml'
+}
+
 subprojects {
     task allDeps(type: DependencyReportTask) {}
 }
 
+// Publish the release.yaml as a maven artifact.
+// Note: The maven co-ordinates are versioned using the version for this bundle.
+publishing {
+    publications {
+
+        // Publish the component manifest/release.yaml
+        publishReleaseManifestYaml(MavenPublication) {
+            artifact myReleaseYaml
+
+            pom {
+                name = "Manifest for extensions bundle versions"
+                artifactId = "dev.galasa.extensions.manifest"
+                groupId = 'dev.galasa'
+				version = "0.36.0"
+                description = "Conveys bundle version information to OBR builds."
+                licenses {
+                    license {
+                        name = 'Eclipse Public License - v 2.0'
+                        url = 'https://www.eclipse.org/legal/epl-2.0/t'
+                    }
+                }
+                url = 'https://galasa.dev'
+                developers {
+                    developer {
+                        name = 'Galasa Developer'
+                        email = 'galasadelivery@ibm.com'
+                        organization = 'IBM'
+                        organizationUrl = 'https://www.ibm.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git:://github.com/galasa-dev/extensions'
+                    developerConnection = 'scm:git:git:://github.com/galasa-dev/extensions'
+                    url = 'https://github.com/galasa-dev/extensions'
+                }
+                issueManagement {
+                    system = 'GitHub'
+                    url = 'https://github.com/galasa-dev/projectmanagement/issues'
+                }
+            }
+
+        }
+    }
+
+    repositories {
+        maven {
+            url  = "$targetMaven"
+        
+            if ("$targetMaven".startsWith('http')) {
+                credentials {
+                    username System.getenv('MAVENUSERNAME')
+                    password System.getenv('MAVENPASSWORD')
+                }
+            }
+        }
+    }
+}

--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/build.gradle
@@ -28,3 +28,16 @@ jacocoTestReport {
         html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
     }
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInBOM          = false
+ext.includeInIsolated     = true
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
@@ -26,3 +26,16 @@ dependencies {
     }
     implementation ('com.google.guava:failureaccess:1.0.1')
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInBOM          = false
+ext.includeInIsolated     = true
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false

--- a/galasa-extensions-parent/dev.galasa.cps.rest/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.cps.rest/build.gradle
@@ -23,3 +23,16 @@ dependencies {
     testImplementation(project(':dev.galasa.extensions.mocks'))
     testImplementation 'org.assertj:assertj-core:3.16.1'
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInBOM          = false
+ext.includeInIsolated     = true
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false

--- a/galasa-extensions-parent/dev.galasa.events.kafka/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.events.kafka/build.gradle
@@ -22,3 +22,16 @@ jacocoTestReport {
         html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
     }
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInBOM          = false
+ext.includeInIsolated     = true
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false

--- a/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.extensions.common/build.gradle
@@ -12,3 +12,16 @@ dependencies {
     implementation ('org.apache.httpcomponents:httpcore-osgi:4.4.14')
     implementation ('com.google.code.gson:gson:2.10.1')
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInBOM          = false
+ext.includeInIsolated     = true
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false

--- a/galasa-extensions-parent/dev.galasa.extensions.mocks/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.extensions.mocks/build.gradle
@@ -19,3 +19,16 @@ dependencies {
     implementation ('org.assertj:assertj-core:3.16.1')
     implementation (project(':dev.galasa.extensions.common'))
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.projectName=project.name
+ext.includeInOBR          = false
+ext.includeInMVP          = false
+ext.includeInBOM          = false
+ext.includeInIsolated     = false
+ext.includeInCodeCoverage = false
+ext.includeInJavadoc      = false

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
@@ -28,3 +28,16 @@ jacocoTestReport {
         html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
     }
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInBOM          = false
+ext.includeInIsolated     = true
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false

--- a/release.yaml
+++ b/release.yaml
@@ -4,47 +4,83 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+# -----------------------------------------------------------
+#
+#                         WARNING
+#
+# This file is periodically re-generated from the contents of
+# the repository, so don't make changes here manually please.
+# -----------------------------------------------------------
+
+
 apiVersion: galasa.dev/v1alpha
 kind: Release
 metadata:
   name: galasa-release
 
-
 framework:
   bundles:
 
+
   - artifact: dev.galasa.auth.couchdb
     version: 0.36.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.ras.couchdb
-    version: 0.36.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.cps.etcd
     version: 0.36.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.cps.rest
     version: 0.36.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.extensions.common
-    version: 0.36.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.events.kafka
     version: 0.36.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.extensions.common
+    version: 0.36.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.extensions.mocks
+    version: 0.36.0
+    obr:          false
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
+
+  - artifact: dev.galasa.ras.couchdb
+    version: 0.36.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1902

## Changes
- Gradle builds now generate a release.yaml based on the versions of all bundles in the extensions project, so the build-locally script now copies that file into the actual release.yaml file, which removes the need to manually update bundle versions in the release.yaml.
- Updated the release.yaml based on the results from running the modified build-locally script