### PR TITLE
Separate external User bean from its internal usage, add Dex user ID to token records

### DIFF
--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthStore.java
@@ -22,8 +22,8 @@ import dev.galasa.extensions.common.couchdb.CouchdbValidator;
 import dev.galasa.extensions.common.couchdb.pojos.ViewRow;
 import dev.galasa.extensions.common.api.HttpRequestFactory;
 import dev.galasa.framework.spi.auth.IInternalAuthToken;
+import dev.galasa.framework.spi.auth.IInternalUser;
 import dev.galasa.framework.spi.auth.IAuthStore;
-import dev.galasa.framework.spi.auth.User;
 import dev.galasa.framework.spi.utils.ITimeService;
 import dev.galasa.framework.spi.auth.AuthStoreException;
 
@@ -94,9 +94,10 @@ public class CouchdbAuthStore extends CouchdbStore implements IAuthStore {
     }
 
     @Override
-    public void storeToken(String clientId, String description, User owner) throws AuthStoreException {
+    public void storeToken(String clientId, String description, IInternalUser owner) throws AuthStoreException {
         // Create the JSON payload representing the token to store
-        String tokenJson = gson.toJson(new CouchdbAuthToken(clientId, description, timeService.now(), owner));
+        CouchdbUser couchdbUser = new CouchdbUser(owner);
+        String tokenJson = gson.toJson(new CouchdbAuthToken(clientId, description, timeService.now(), couchdbUser));
 
         try {
             createDocument(TOKENS_DATABASE_NAME, tokenJson);

--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthToken.java
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbAuthToken.java
@@ -8,7 +8,7 @@ package dev.galasa.auth.couchdb.internal;
 import java.time.Instant;
 
 import dev.galasa.framework.spi.auth.IInternalAuthToken;
-import dev.galasa.framework.spi.auth.User;
+import dev.galasa.framework.spi.auth.IInternalUser;
 
 public class CouchdbAuthToken implements IInternalAuthToken {
 
@@ -16,16 +16,16 @@ public class CouchdbAuthToken implements IInternalAuthToken {
     private String dexClientId;
     private String description;
     private Instant creationTime;
-    private User owner;
+    private CouchdbUser owner;
 
-    public CouchdbAuthToken(String clientId, String description, Instant creationTime, User owner) {
+    public CouchdbAuthToken(String clientId, String description, Instant creationTime, CouchdbUser owner) {
         this.dexClientId = clientId;
         this.description = description;
         this.creationTime = creationTime;
         this.owner = owner;
     }
 
-    public CouchdbAuthToken(String documentId, String clientId, String description, Instant creationTime, User owner) {
+    public CouchdbAuthToken(String documentId, String clientId, String description, Instant creationTime, CouchdbUser owner) {
         this(clientId, description, creationTime, owner);
         this._id = documentId;
     }
@@ -42,7 +42,7 @@ public class CouchdbAuthToken implements IInternalAuthToken {
         return creationTime;
     }
 
-    public User getOwner() {
+    public IInternalUser getOwner() {
         return owner;
     }
 

--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbUser.java
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbUser.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.auth.couchdb.internal;
+
+import dev.galasa.framework.spi.auth.IInternalUser;
+
+public class CouchdbUser implements IInternalUser {
+    
+    private String loginId;
+    private String dexUserId;
+
+    public CouchdbUser(String loginId, String dexUserId) {
+        this.loginId = loginId;
+        this.dexUserId = dexUserId;
+    }
+
+    public CouchdbUser(IInternalUser user) {
+        this.loginId = user.getLoginId();
+        this.dexUserId = user.getDexUserId();
+    }
+
+    @Override
+    public String getDexUserId() {
+        return dexUserId;
+    }
+
+    @Override
+    public String getLoginId() {
+        return loginId;
+    }
+}

--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/TestCouchdbAuthStore.java
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/src/test/java/dev/galasa/auth/couchdb/TestCouchdbAuthStore.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import dev.galasa.auth.couchdb.internal.CouchdbAuthStore;
 import dev.galasa.auth.couchdb.internal.CouchdbAuthToken;
+import dev.galasa.auth.couchdb.internal.CouchdbUser;
 import dev.galasa.extensions.common.couchdb.pojos.IdRev;
 import dev.galasa.extensions.common.couchdb.pojos.PutPostResponse;
 import dev.galasa.extensions.common.couchdb.pojos.ViewResponse;
@@ -33,7 +34,6 @@ import dev.galasa.extensions.mocks.MockTimeService;
 import dev.galasa.extensions.mocks.couchdb.MockCouchdbValidator;
 import dev.galasa.framework.spi.auth.AuthStoreException;
 import dev.galasa.framework.spi.auth.IInternalAuthToken;
-import dev.galasa.framework.spi.auth.User;
 
 public class TestCouchdbAuthStore {
 
@@ -135,7 +135,7 @@ public class TestCouchdbAuthStore {
         ViewResponse mockAllDocsResponse = new ViewResponse();
         mockAllDocsResponse.rows = mockDocs;
 
-        CouchdbAuthToken mockToken = new CouchdbAuthToken("token1", "dex-client", "my test token", Instant.now(), new User("johndoe"));
+        CouchdbAuthToken mockToken = new CouchdbAuthToken("token1", "dex-client", "my test token", Instant.now(), new CouchdbUser("johndoe", "dex-user-id"));
         List<HttpInteraction> interactions = new ArrayList<HttpInteraction>();
         interactions.add(new GetAllTokenDocumentsInteraction("https://my-auth-store/galasa_tokens/_all_docs", HttpStatus.SC_OK, mockAllDocsResponse));
         interactions.add(new GetTokenDocumentInteraction<CouchdbAuthToken>("https://my-auth-store/galasa_tokens/token1", HttpStatus.SC_OK, mockToken));
@@ -174,7 +174,7 @@ public class TestCouchdbAuthStore {
         CouchdbAuthStore authStore = new CouchdbAuthStore(authStoreUri, httpClientFactory, new HttpRequestFactoryImpl(), logFactory, new MockCouchdbValidator(), mockTimeService);
 
         // When...
-        authStore.storeToken("this-is-a-dex-id", "my token", new User("user1"));
+        authStore.storeToken("this-is-a-dex-id", "my token", new CouchdbUser("user1", "user1-id"));
 
         // Then the assertions made in the create token document interaction shouldn't have failed.
     }
@@ -196,7 +196,7 @@ public class TestCouchdbAuthStore {
         CouchdbAuthStore authStore = new CouchdbAuthStore(authStoreUri, httpClientFactory, new HttpRequestFactoryImpl(), logFactory, new MockCouchdbValidator(), mockTimeService);
 
         // When...
-        AuthStoreException thrown = catchThrowableOfType(() -> authStore.storeToken("this-is-a-dex-id", "my token", new User("user1")), AuthStoreException.class);
+        AuthStoreException thrown = catchThrowableOfType(() -> authStore.storeToken("this-is-a-dex-id", "my token", new CouchdbUser("user1", "user1-id")), AuthStoreException.class);
 
         // Then...
         assertThat(thrown).isNotNull();


### PR DESCRIPTION
## Why?
See story https://github.com/galasa-dev/projectmanagement/issues/1729
Related to changes in https://github.com/galasa-dev/framework/pull/588

**Note: Builds for this PR will fail until the above is reviewed and merged**

## Changes
- Added a CouchdbUser implementation to store user details within CouchDB, separate from the User bean which was being used in API server responses as well
  - Added the Dex user ID into the `owner` object in token documents alongside user login IDs