### PR TITLE
Fix loginId not correctly deserialising with existing couchdb token documents

### DIFF
--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/bnd.bnd
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/bnd.bnd
@@ -3,6 +3,7 @@ Bundle-Name: dev.galasa.auth.couchdb
 Bundle-Description: A CouchDB implementation of the Galasa Auth Store
 Bundle-License: https://www.eclipse.org/legal/epl-2.0
 Import-Package: com.google.gson,\
+    com.google.gson.annotations,\
     dev.galasa,\
     dev.galasa.framework.spi,\
     dev.galasa.framework.spi.auth,\

--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbUser.java
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/src/main/java/dev/galasa/auth/couchdb/internal/CouchdbUser.java
@@ -5,10 +5,13 @@
  */
 package dev.galasa.auth.couchdb.internal;
 
+import com.google.gson.annotations.SerializedName;
+
 import dev.galasa.framework.spi.auth.IInternalUser;
 
 public class CouchdbUser implements IInternalUser {
     
+    @SerializedName(value = "loginId", alternate = { "login_id" })
     private String loginId;
     private String dexUserId;
 


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/extensions/pull/248

Token documents created in the past used `login_id`, which has now become `loginId` internally for consistency with other token document fields like `creationTime`, `dexClientId`, etc. Because of this, the `login_id` was not being correctly deserialised with GSON, so this PR fixes the issue.