### PR TITLE
extension should not insist on down-level gson version

### DIFF
--- a/galasa-extensions-parent/dev.galasa.cps.rest/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.cps.rest/build.gradle
@@ -10,9 +10,7 @@ version = '0.36.0'
 dependencies {
 
     // Not required for compile,  but required to force the download of the jars to embed by bnd
-    implementation ('dev.galasa:gson:2.8.5') {
-       force = true
-    }
+    implementation ('dev.galasa:gson:2.10.1')
     implementation ('dev.galasa:dev.galasa.framework.api.beans:0.33.0')
     implementation (project(':dev.galasa.extensions.common'))
     implementation 'commons-io:commons-io:2.16.1'


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
RESTCPS extension was using a down-level version of gson, and insisting on only having that level.
