### PR TITLE
Fix GH workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,13 @@ jobs:
           -PtargetMaven=${{ github.workspace }}/repo \
           -PjacocoEnabled=true \
           -PisMainOrRelease=true
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Extract metadata for Extensions image
         id: metadata


### PR DESCRIPTION
Must login to the GHCR before we can push the new image there.