### PR TITLE
Add support for Gradle 8

### DIFF
--- a/galasa-extensions-parent/build.gradle
+++ b/galasa-extensions-parent/build.gradle
@@ -4,13 +4,13 @@ plugins {
     id 'maven-publish'
 }
 
-version = '0.15.0'
+version = '0.36.0'
 
 task clean {
-   // make sure the build directory is gone 
-   doFirst {
-      delete "${buildDir}"
-   }
+    // make sure the build directory is gone
+    doFirst {
+        delete layout.buildDirectory
+    }
 }
 
 //---------------------------------------------------------------
@@ -32,7 +32,7 @@ configurations {
     release_metadata
 }
 
-def overallManifestFilePath = "$buildDir/release.yaml"
+def overallManifestFile = layout.buildDirectory.file("release.yaml").get().asFile
 def overallHeader = """#
 # Copyright contributors to the Galasa project
 #
@@ -57,13 +57,12 @@ framework:
   bundles:
 """
 
-//----------------------------------------------------------
-// Flushes any existing content on the specified path, and
-// creates a new file, containing the header text.
-//----------------------------------------------------------
-def prepareGeneratedFile(path, header) {
+//---------------------------------------------------------------
+// Flushes any existing content in the given manifest file, and
+// replaces it with a fresh file containing only the header text.
+//---------------------------------------------------------------
+def prepareGeneratedFile(manifestFile, header) {
     // Make sure the manifest file is clean, and exists.
-    def manifestFile = new File(path)
     if (manifestFile.exists()) {
         // File exists, delete it and create a new one.
         manifestFile.delete()
@@ -84,11 +83,12 @@ task buildReleaseYaml() {
     // During execution phase, make sure the file exists.
     doFirst {
         // Make sure the build directory exists.
+        def buildDir = layout.buildDirectory.get().asFile
         if (!buildDir.exists()) {
             buildDir.mkdirs()
         }
 
-        prepareGeneratedFile(overallManifestFilePath, overallHeader)
+        prepareGeneratedFile(overallManifestFile, overallHeader)
     }
 
     subprojects {
@@ -112,26 +112,25 @@ task buildReleaseYaml() {
                         throw new Exception("Project has no name.")
                     }
 
-                    def f = new File(overallManifestFilePath)
-                    f.append("\n\n  - artifact: $projectName")
-                    f.append("\n    version: $version")
+                    overallManifestFile.append("\n\n  - artifact: $projectName")
+                    overallManifestFile.append("\n    version: $version")
                     if (includeInOBR != '') {
-                        f.append("\n    obr:          $includeInOBR")
+                        overallManifestFile.append("\n    obr:          $includeInOBR")
                     }
                     if (includeInMVP != '') {
-                        f.append("\n    mvp:          $includeInMVP")
+                        overallManifestFile.append("\n    mvp:          $includeInMVP")
                     }
                     if (includeInBOM != '') {
-                        f.append("\n    bom:          $includeInBOM")
+                        overallManifestFile.append("\n    bom:          $includeInBOM")
                     }
                     if (includeInJavadoc != '') {
-                        f.append("\n    javadoc:      $includeInJavadoc")
+                        overallManifestFile.append("\n    javadoc:      $includeInJavadoc")
                     }
                     if (includeInIsolated != '') {
-                        f.append("\n    isolated:     $includeInIsolated")
+                        overallManifestFile.append("\n    isolated:     $includeInIsolated")
                     }
                     if (includeInCodeCoverage != '') {
-                        f.append("\n    codecoverage: $includeInCodeCoverage")
+                        overallManifestFile.append("\n    codecoverage: $includeInCodeCoverage")
                     }
 
                 }
@@ -141,7 +140,7 @@ task buildReleaseYaml() {
 }
 
 // Declare that the uber-manifest release.yaml file exists, and how to build it.
-def myReleaseYaml = artifacts.add('release_metadata', file(overallManifestFilePath)) {
+def myReleaseYaml = artifacts.add('release_metadata', overallManifestFile) {
     builtBy 'buildReleaseYaml'
 }
 

--- a/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
+++ b/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.java.gradle
@@ -20,9 +20,9 @@ tasks.withType(Javadoc) {
 }
 
 task gitHash(dependsOn : 'classes') {
-    def dir    = file("${buildDir}/githash")
-    def meta   = file("${buildDir}/githash/META-INF")
-    def result = file("${buildDir}/githash/META-INF/git.hash")
+    def dir    = layout.buildDirectory.dir("githash").get().asFile
+    def meta   = layout.buildDirectory.dir("githash/META-INF").get().asFile
+    def result = layout.buildDirectory.file("githash/META-INF/git.hash").get().asFile
     
     outputs.dir meta
     tasks.jar.dependsOn('gitHash')

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/build.gradle
@@ -11,9 +11,7 @@ dependencies {
     implementation ('io.etcd:jetcd-core:0.5.9')
     
     // Not required for compile,  but required to force the download of the jars to embed by bnd
-    implementation ('com.google.code.gson:gson:2.10.1') {
-       force = true
-    }
+    implementation ('com.google.code.gson:gson:2.10.1')
     implementation ('org.codehaus.mojo:animal-sniffer-annotations:1.19')
     implementation ('com.google.android:annotations:4.1.1.4')
     implementation ('io.perfmark:perfmark-api:0.23.0')
@@ -21,9 +19,7 @@ dependencies {
     implementation ('io.netty:netty-codec-socks:4.1.86.Final')
     implementation ('io.netty:netty-codec-http2:4.1.86.Final')
     implementation ('com.google.protobuf:protobuf-java-util:3.17.2')
-    implementation ('com.google.guava:guava:30.1.1-jre') {
-       force = true
-    }
+    implementation ('com.google.guava:guava:30.1.1-jre')
     implementation ('com.google.guava:failureaccess:1.0.1')
 }
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1652

Fixes build errors when building Galasa's gradle plugins using Gradle 8 (tested on Gradle 8.9), while also continuing to support the use of Gradle 6 and 7 (tested on 6.8.2 and 7.5.1).