### PR TITLE
Add signing to dev.galasa.extensions.manifest artifact

### DIFF
--- a/galasa-extensions-parent/build.gradle
+++ b/galasa-extensions-parent/build.gradle
@@ -2,16 +2,10 @@ plugins {
     id 'biz.aQute.bnd.builder' version '5.3.0' apply false
     id 'dev.galasa.githash' version '0.15.0' apply false
     id 'maven-publish'
+    id 'signing'
 }
 
 version = '0.36.0'
-
-task clean {
-    // make sure the build directory is gone
-    doFirst {
-        delete layout.buildDirectory
-    }
-}
 
 //---------------------------------------------------------------
 // We need to gather the release and packaging metadata from each
@@ -146,6 +140,18 @@ def myReleaseYaml = artifacts.add('release_metadata', overallManifestFile) {
 
 subprojects {
     task allDeps(type: DependencyReportTask) {}
+}
+
+signing {
+    def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    sign publishing.publications
+}
+
+tasks.withType(Sign) {
+    onlyIf { isMainOrRelease.toBoolean() }
 }
 
 // Publish the release.yaml as a maven artifact.


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1952

The dev.galasa.extensions.manifest artifact is not currently being signed like the managers manifest, so this PR adds the missing signing for that artifact.