### PR TITLE
Implement functions to get the cursor for queries to CouchDB

### DIFF
--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
@@ -321,7 +321,7 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
     }
 
     @Override
-    public @NotNull List<IRunResult> getRuns(@NotNull IRasSearchCriteria... searchCriterias)
+    public @NotNull List<IRunResult> getRuns(int maxResults, @NotNull IRasSearchCriteria... searchCriterias)
             throws ResultArchiveStoreException {
 
         if (searchCriterias.length == 0) {
@@ -335,7 +335,7 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
         Find find = new Find();
         find.selector = buildGetRunsQuery(searchCriterias);
         find.execution_stats = true;
-        find.limit = COUCHDB_RESULTS_LIMIT_PER_QUERY;
+        find.limit = maxResults;
 
         while (true) {
             String requestContent = store.getGson().toJson(find);
@@ -383,6 +383,12 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
         }
 
         return runs;
+    }
+
+    @Override
+    public @NotNull List<IRunResult> getRuns(@NotNull IRasSearchCriteria... searchCriterias)
+            throws ResultArchiveStoreException {
+        return getRuns(COUCHDB_RESULTS_LIMIT_PER_QUERY, searchCriterias);
     }
 
     public void discardRun(String id) throws ResultArchiveStoreException {

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
@@ -323,7 +323,7 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
     }
 
     @Override
-    public @NotNull RasRunResultPage getRunsPage(int maxResults, List<RasSortField> sortFields, String pageToken, @NotNull IRasSearchCriteria... searchCriterias)
+    public @NotNull RasRunResultPage getRunsPage(int maxResults, RasSortField primarySort, String pageToken, @NotNull IRasSearchCriteria... searchCriterias)
             throws ResultArchiveStoreException {
 
         HttpPost httpPost = requestFactory.getHttpPostRequest(store.getCouchdbUri() + "/galasa_run/_find");
@@ -333,8 +333,8 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
         find.execution_stats = true;
         find.limit = maxResults;
         find.bookmark = pageToken;
-        if (sortFields != null && !sortFields.isEmpty()) {
-            find.sort = buildQuerySortJson(sortFields);
+        if (primarySort != null) {
+            find.sort = buildQuerySortJson(primarySort);
         }
 
         return getRunsPageFromCouchdb(httpPost, find);
@@ -383,11 +383,10 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
         return runsPage;
     }
 
-    private JsonArray buildQuerySortJson(@NotNull List<RasSortField> sortFields) {
+    private JsonArray buildQuerySortJson(@NotNull RasSortField primarySort) {
         JsonArray sort = new JsonArray();
 
         JsonObject primarySortJson = new JsonObject();
-        RasSortField primarySort = sortFields.get(0);
         primarySortJson.addProperty(primarySort.getFieldName(), primarySort.getSortDirection());
 
         sort.add(primarySortJson);
@@ -422,7 +421,7 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
                 break;
             }
 
-            find.bookmark = runsPage.getNextPageToken();
+            find.bookmark = runsPage.getNextCursor();
         }
 
         return runs;

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImpl.java
@@ -69,6 +69,8 @@ public class CouchdbValidatorImpl implements CouchdbValidator {
             checkIndex(httpClient, rasUri, 1, "galasa_run", "runName");
             checkIndex(httpClient, rasUri, 1, "galasa_run", "requestor");
             checkIndex(httpClient, rasUri, 1, "galasa_run", "queued");
+            checkIndex(httpClient, rasUri, 1, "galasa_run", "startTime");
+            checkIndex(httpClient, rasUri, 1, "galasa_run", "endTime");
             checkIndex(httpClient, rasUri, 1, "galasa_run", "testName");
             checkIndex(httpClient, rasUri, 1, "galasa_run", "bundle");
             checkIndex(httpClient, rasUri, 1, "galasa_run", "result");

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/pojos/Find.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/pojos/Find.java
@@ -5,13 +5,15 @@
  */
 package dev.galasa.ras.couchdb.internal.pojos;
 
+import com.google.gson.JsonArray;
+
 public class Find {
 
-    public Object  selector;        // NOSONAR
-//	public List<Sort> sort; // NOSONAR
-    public Integer limit;           // NOSONAR
-    public Integer skip;            // NOSONAR
-    public Boolean execution_stats; // NOSONAR
-    public String  bookmark;        // NOSONAR
+    public Object    selector;
+	public JsonArray sort;
+    public Integer   limit;
+    public Integer   skip;
+    public Boolean   execution_stats;
+    public String    bookmark;
 
 }

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/pojos/Find.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/pojos/Find.java
@@ -10,7 +10,7 @@ import com.google.gson.JsonArray;
 public class Find {
 
     public Object    selector;
-	public JsonArray sort;
+    public JsonArray sort;
     public Integer   limit;
     public Integer   skip;
     public Boolean   execution_stats;

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
@@ -359,7 +359,7 @@ public class CouchdbDirectoryServiceTest {
         RasRunResultPage runsPage = directoryService.getRunsPage(maxResults, null, null, queuedFrom);
 
         // Then...
-        assertThat(runsPage.getNextPageToken()).isEqualTo(findRunsResponse.bookmark);
+        assertThat(runsPage.getNextCursor()).isEqualTo(findRunsResponse.bookmark);
 
         List<IRunResult> runs = runsPage.getRuns();
         assertThat(runs).hasSize(2);
@@ -377,7 +377,6 @@ public class CouchdbDirectoryServiceTest {
         RasSearchCriteriaQueuedFrom queuedFrom = new RasSearchCriteriaQueuedFrom(queuedFromTime);
 
         RasSortField runNameSort = new RasSortField("runName", "desc");
-        List<RasSortField> sortFields = List.of(runNameSort);
 
         FoundRuns findRunsResponse = new FoundRuns();
         findRunsResponse.docs = List.of(mockRun1, mockRun2);
@@ -407,10 +406,10 @@ public class CouchdbDirectoryServiceTest {
         int maxResults = 100;
 
         // When...
-        RasRunResultPage runsPage = directoryService.getRunsPage(maxResults, sortFields, null, queuedFrom);
+        RasRunResultPage runsPage = directoryService.getRunsPage(maxResults, runNameSort, null, queuedFrom);
 
         // Then...
-        assertThat(runsPage.getNextPageToken()).isEqualTo(findRunsResponse.bookmark);
+        assertThat(runsPage.getNextCursor()).isEqualTo(findRunsResponse.bookmark);
 
         List<IRunResult> runs = runsPage.getRuns();
         assertThat(runs).hasSize(2);
@@ -428,7 +427,6 @@ public class CouchdbDirectoryServiceTest {
         RasSearchCriteriaQueuedFrom queuedFrom = new RasSearchCriteriaQueuedFrom(queuedFromTime);
 
         RasSortField runNameSort = new RasSortField("runName", "desc");
-        List<RasSortField> sortFields = List.of(runNameSort);
 
         FoundRuns findRunsResponse = new FoundRuns();
         findRunsResponse.docs = List.of(mockRun1, mockRun2);
@@ -462,10 +460,10 @@ public class CouchdbDirectoryServiceTest {
         int maxResults = 100;
 
         // When...
-        RasRunResultPage runsPage = directoryService.getRunsPage(maxResults, sortFields, bookmarkToRequest, queuedFrom);
+        RasRunResultPage runsPage = directoryService.getRunsPage(maxResults, runNameSort, bookmarkToRequest, queuedFrom);
 
         // Then...
-        assertThat(runsPage.getNextPageToken()).isEqualTo(findRunsResponse.bookmark);
+        assertThat(runsPage.getNextCursor()).isEqualTo(findRunsResponse.bookmark);
 
         List<IRunResult> runs = runsPage.getRuns();
         assertThat(runs).hasSize(2);

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryServiceTest.java
@@ -28,6 +28,7 @@ import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.ras.IRasSearchCriteria;
+import dev.galasa.framework.spi.ras.RasRunResultPage;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaBundle;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaQueuedFrom;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaQueuedTo;
@@ -36,6 +37,7 @@ import dev.galasa.framework.spi.ras.RasSearchCriteriaResult;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaRunName;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaStatus;
 import dev.galasa.framework.spi.ras.RasSearchCriteriaTestName;
+import dev.galasa.framework.spi.ras.RasSortField;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 import dev.galasa.ras.couchdb.internal.mocks.CouchdbTestFixtures;
 import dev.galasa.ras.couchdb.internal.mocks.MockLogFactory;
@@ -324,5 +326,150 @@ public class CouchdbDirectoryServiceTest {
         // Then...
         assertThat(thrown).isNotNull();
         assertThat(thrown.getMessage()).contains("Unrecognised search criteria");
+    }
+
+    @Test
+    public void testGetRunsPageByQueuedFromReturnsRunsOk() throws Exception {
+        // Given...
+        TestStructureCouchdb mockRun1 = createRunTestStructure("run1");
+        TestStructureCouchdb mockRun2 = createRunTestStructure("run2");
+
+        Instant queuedFromTime = Instant.EPOCH;
+        RasSearchCriteriaQueuedFrom queuedFrom = new RasSearchCriteriaQueuedFrom(queuedFromTime);
+
+        FoundRuns findRunsResponse = new FoundRuns();
+        findRunsResponse.docs = List.of(mockRun1, mockRun2);
+        findRunsResponse.bookmark = "bookmark!";
+
+        FoundRuns emptyRunsResponse = new FoundRuns();
+        emptyRunsResponse.docs = new ArrayList<>();
+
+        String expectedUri = "http://my.uri/galasa_run/_find";
+        List<HttpInteraction> interactions = List.of(
+            new PostCouchdbFindRunsInteraction(expectedUri, findRunsResponse, "queued", "$gte", queuedFromTime.toString())
+        );
+
+        MockLogFactory mockLogFactory = new MockLogFactory();
+        CouchdbRasStore mockRasStore = fixtures.createCouchdbRasStore(interactions, mockLogFactory);
+        CouchdbDirectoryService directoryService = new CouchdbDirectoryService(mockRasStore, mockLogFactory, new HttpRequestFactoryImpl());
+
+        int maxResults = 100;
+
+        // When...
+        RasRunResultPage runsPage = directoryService.getRunsPage(maxResults, null, null, queuedFrom);
+
+        // Then...
+        assertThat(runsPage.getNextPageToken()).isEqualTo(findRunsResponse.bookmark);
+
+        List<IRunResult> runs = runsPage.getRuns();
+        assertThat(runs).hasSize(2);
+        assertThat(runs.get(0).getTestStructure().getRunName()).isEqualTo(mockRun1.getRunName());
+        assertThat(runs.get(1).getTestStructure().getRunName()).isEqualTo(mockRun2.getRunName());
+    }
+
+    @Test
+    public void testGetRunsPageByQueuedFromWithSortReturnsRunsOk() throws Exception {
+        // Given...
+        TestStructureCouchdb mockRun1 = createRunTestStructure("run1");
+        TestStructureCouchdb mockRun2 = createRunTestStructure("run2");
+
+        Instant queuedFromTime = Instant.EPOCH;
+        RasSearchCriteriaQueuedFrom queuedFrom = new RasSearchCriteriaQueuedFrom(queuedFromTime);
+
+        RasSortField runNameSort = new RasSortField("runName", "desc");
+        List<RasSortField> sortFields = List.of(runNameSort);
+
+        FoundRuns findRunsResponse = new FoundRuns();
+        findRunsResponse.docs = List.of(mockRun1, mockRun2);
+        findRunsResponse.bookmark = "bookmark!";
+
+        FoundRuns emptyRunsResponse = new FoundRuns();
+        emptyRunsResponse.docs = new ArrayList<>();
+
+        String expectedUri = "http://my.uri/galasa_run/_find";
+        List<HttpInteraction> interactions = List.of(
+            new PostCouchdbFindRunsInteraction(
+                expectedUri,
+                findRunsResponse,
+                "queued",
+                "$gte",
+                queuedFromTime.toString(),
+                "sort",
+                runNameSort.getFieldName(),
+                runNameSort.getSortDirection()
+            )
+        );
+
+        MockLogFactory mockLogFactory = new MockLogFactory();
+        CouchdbRasStore mockRasStore = fixtures.createCouchdbRasStore(interactions, mockLogFactory);
+        CouchdbDirectoryService directoryService = new CouchdbDirectoryService(mockRasStore, mockLogFactory, new HttpRequestFactoryImpl());
+
+        int maxResults = 100;
+
+        // When...
+        RasRunResultPage runsPage = directoryService.getRunsPage(maxResults, sortFields, null, queuedFrom);
+
+        // Then...
+        assertThat(runsPage.getNextPageToken()).isEqualTo(findRunsResponse.bookmark);
+
+        List<IRunResult> runs = runsPage.getRuns();
+        assertThat(runs).hasSize(2);
+        assertThat(runs.get(0).getTestStructure().getRunName()).isEqualTo(mockRun1.getRunName());
+        assertThat(runs.get(1).getTestStructure().getRunName()).isEqualTo(mockRun2.getRunName());
+    }
+
+    @Test
+    public void testGetRunsPageByQueuedFromWithSortAndPageTokenReturnsRunsOk() throws Exception {
+        // Given...
+        TestStructureCouchdb mockRun1 = createRunTestStructure("run1");
+        TestStructureCouchdb mockRun2 = createRunTestStructure("run2");
+
+        Instant queuedFromTime = Instant.EPOCH;
+        RasSearchCriteriaQueuedFrom queuedFrom = new RasSearchCriteriaQueuedFrom(queuedFromTime);
+
+        RasSortField runNameSort = new RasSortField("runName", "desc");
+        List<RasSortField> sortFields = List.of(runNameSort);
+
+        FoundRuns findRunsResponse = new FoundRuns();
+        findRunsResponse.docs = List.of(mockRun1, mockRun2);
+        findRunsResponse.bookmark = "bookmark!";
+
+        FoundRuns emptyRunsResponse = new FoundRuns();
+        emptyRunsResponse.docs = new ArrayList<>();
+
+        String bookmarkToRequest = "iwantthispage";
+
+        String expectedUri = "http://my.uri/galasa_run/_find";
+        List<HttpInteraction> interactions = List.of(
+            new PostCouchdbFindRunsInteraction(
+                expectedUri,
+                findRunsResponse,
+                "queued",
+                "$gte",
+                queuedFromTime.toString(),
+                "sort",
+                runNameSort.getFieldName(),
+                runNameSort.getSortDirection(),
+                "bookmark",
+                bookmarkToRequest
+            )
+        );
+
+        MockLogFactory mockLogFactory = new MockLogFactory();
+        CouchdbRasStore mockRasStore = fixtures.createCouchdbRasStore(interactions, mockLogFactory);
+        CouchdbDirectoryService directoryService = new CouchdbDirectoryService(mockRasStore, mockLogFactory, new HttpRequestFactoryImpl());
+
+        int maxResults = 100;
+
+        // When...
+        RasRunResultPage runsPage = directoryService.getRunsPage(maxResults, sortFields, bookmarkToRequest, queuedFrom);
+
+        // Then...
+        assertThat(runsPage.getNextPageToken()).isEqualTo(findRunsResponse.bookmark);
+
+        List<IRunResult> runs = runsPage.getRuns();
+        assertThat(runs).hasSize(2);
+        assertThat(runs.get(0).getTestStructure().getRunName()).isEqualTo(mockRun1.getRunName());
+        assertThat(runs.get(1).getTestStructure().getRunName()).isEqualTo(mockRun2.getRunName());
     }
 }

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
@@ -9,6 +9,7 @@ import java.util.*;
 import static org.assertj.core.api.Assertions.*;
 
 import org.apache.http.*;
+import org.apache.http.client.methods.HttpPost;
 import org.junit.*;
 import org.junit.rules.TestName;
 
@@ -234,13 +235,17 @@ public class CouchdbValidatorImplTest {
 
     public static class CheckIndexPOSTInteraction extends WelcomeInteractionOK {
 
-        public CheckIndexPOSTInteraction() {
+        private String[] expectedIndexFields;
+
+        public CheckIndexPOSTInteraction(String... expectedIndexFields) {
             super();
+            this.expectedIndexFields = expectedIndexFields;
         }
         
         @Override
         public void validateRequest(HttpHost host, HttpRequest request) throws RuntimeException {
             super.validateRequest(host,request,"POST");
+            validatePostRequestBody((HttpPost) request, expectedIndexFields);
         }
 
         @Override
@@ -294,23 +299,21 @@ public class CouchdbValidatorImplTest {
 
         //Check Indexes Interactions
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("runName"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("requestor"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("queued"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("startTime"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("endTime"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("testName"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("bundle"));
         interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction());
-        interactions.add( new CheckDatabaseHasDocumentInteraction());
-        interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckIndexPOSTInteraction("result"));
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/CouchdbValidatorImplTest.java
@@ -307,6 +307,10 @@ public class CouchdbValidatorImplTest {
         interactions.add( new CheckIndexPOSTInteraction());
         interactions.add( new CheckDatabaseHasDocumentInteraction());
         interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction());
+        interactions.add( new CheckDatabaseHasDocumentInteraction());
+        interactions.add( new CheckIndexPOSTInteraction());
 
         MockCloseableHttpClient mockHttpClient = new MockCloseableHttpClient(interactions);
 

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/CouchdbTestFixtures.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/test/java/dev/galasa/ras/couchdb/internal/mocks/CouchdbTestFixtures.java
@@ -21,6 +21,7 @@ import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.util.EntityUtils;
 
 import dev.galasa.extensions.common.couchdb.pojos.PutPostResponse;
@@ -86,6 +87,16 @@ public class CouchdbTestFixtures {
         public void validateRequestContentType(HttpRequest request) {
             assertThat(request.containsHeader("Content-Type")).as("Missing Content-Type header!").isTrue();
             assertThat(request.getHeaders("Content-Type")[0].getValue()).isEqualTo(getExpectedHttpContentType());
+        }
+
+        public void validatePostRequestBody(HttpPost postRequest, String... expectedRequestBodyParts) {
+            try {
+                String requestBody = EntityUtils.toString(postRequest.getEntity());
+                assertThat(requestBody).contains(expectedRequestBodyParts);
+
+            } catch (IOException ex) {
+                fail("Failed to parse POST request body");
+            }
         }
 
     }


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1921
Related to changes in https://github.com/galasa-dev/framework/pull/623

## Changes
- Implemented `getRunsPage` method to retrieve an individual page of runs stored in CouchDB and the associated cursor/bookmark pointing to the next page of runs
- Passed sort value into CouchDB page queries to maintain result sorting between pages
- Added indexes for `startTime` and `endTime` run result fields

**Note: Builds for this PR will fail until https://github.com/galasa-dev/framework/pull/623 is reviewed and merged**