### PR TITLE
Convert 'nil' bookmark string from couchdb to an actual null value

### DIFF
--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbDirectoryService.java
@@ -374,6 +374,12 @@ public class CouchdbDirectoryService implements IResultArchiveStoreDirectoryServ
                 }
             }
 
+            // CouchDB sometimes returns a 'nil' string as a bookmark to indicate no bookmark,
+            // so turn it into an actual null value
+            if (found.bookmark != null && found.bookmark.equals("nil")) {
+                found.bookmark = null;
+            }
+
             runsPage = new RasRunResultPage(runs, found.bookmark);
         } catch (CouchdbRasException e) {
             throw e;


### PR DESCRIPTION
## Why?
Related to story https://github.com/galasa-dev/projectmanagement/issues/1921

Fixes an issue where CouchDB returns "nil" bookmarks for some queries instead of omitting the bookmark.