### PR TITLE
Implement sleepMillis in MockTimeService to fix main build failures

### DIFF
--- a/galasa-extensions-parent/dev.galasa.extensions.mocks/src/main/java/dev/galasa/extensions/mocks/MockTimeService.java
+++ b/galasa-extensions-parent/dev.galasa.extensions.mocks/src/main/java/dev/galasa/extensions/mocks/MockTimeService.java
@@ -25,4 +25,10 @@ public class MockTimeService implements ITimeService {
     public void setCurrentTime(Instant currentTime) {
         this.currentTime = currentTime;
     }
+
+    @Override
+    public void sleepMillis(long millisToSleep) throws InterruptedException {
+        // Pretend we are sleeping, so the current time advances.
+        setCurrentTime(currentTime.plusMillis(millisToSleep));
+    }
 }


### PR DESCRIPTION
## Why?
Extension main builds are currently broken due to changes in https://github.com/galasa-dev/framework/pull/645, so this PR fixes these build failures.