### PR TITLE
Implement loadArtifacts method and stop fetchRun from loading run artifacts by default

### DIFF
--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/src/main/java/dev/galasa/ras/couchdb/internal/CouchdbRunResult.java
@@ -18,10 +18,12 @@ public class CouchdbRunResult implements IRunResult {
 
     private final TestStructureCouchdb   testStructure;
     private final CouchdbRasStore store;
+    private final CouchdbDirectoryService storeService;
     private Path path;
 
     public CouchdbRunResult(CouchdbRasStore store, TestStructureCouchdb testStructure, LogFactory logFactory) {
         this.store = store;
+        this.storeService = (CouchdbDirectoryService) store.getDirectoryServices().get(0);
         if (testStructure == null) {
             this.testStructure = new TestStructureCouchdb();
         } else {
@@ -50,7 +52,6 @@ public class CouchdbRunResult implements IRunResult {
 
 	@Override
 	public void discard() throws ResultArchiveStoreException {
-        CouchdbDirectoryService storeService =  (CouchdbDirectoryService) store.getDirectoryServices().get(0);
         storeService.discardRun(this.testStructure);
 	}
 
@@ -61,7 +62,6 @@ public class CouchdbRunResult implements IRunResult {
 
     @Override
     public void loadArtifacts() throws ResultArchiveStoreException {
-        CouchdbDirectoryService storeService = (CouchdbDirectoryService) store.getDirectoryServices().get(0);
         this.path = storeService.getRunArtifactPath(this.testStructure);
     }
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1210
Related to changes in https://github.com/galasa-dev/framework/pull/649

## Changes
- Implemented the `loadArtifacts` IRunResult method to separate the loading of artifacts out from fetching runs, which has been causing performance issues in several areas (including getting and deleting runs)
- Removed duplicate fetch of a run when deleting it by replacing the `id` parameter in `discardRun` with the test structure of the run to discard

**Note: Builds for this PR will fail until https://github.com/galasa-dev/framework/pull/649 is reviewed and merged**