### PR TITLE
Implement operations to set and delete credentials in etcd

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -75,7 +75,18 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
+  "results": {
+    "galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3CredentialsStoreTest.java": [
+      {
+        "hashed_secret": "1beb7496ebbe82c61151be093956d83dac625c13",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 246,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
   "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,

--- a/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
+++ b/galasa-extensions-parent/buildSrc/src/main/groovy/galasa.extensions.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'galasa.java'
     id 'biz.aQute.bnd.builder'
+    id 'jacoco'
 }
 
 dependencies {
@@ -16,4 +17,17 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.awaitility:awaitility:3.0.0'
     testImplementation 'org.assertj:assertj-core:3.16.1'
+}
+
+test {
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        csv.required = true
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
 }

--- a/galasa-extensions-parent/dev.galasa.auth.couchdb/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.auth.couchdb/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'biz.aQute.bnd.builder'
     id 'galasa.extensions'
-    id 'jacoco'
 }
 
 description = 'Galasa Authentication - CouchDB'
@@ -19,14 +18,6 @@ dependencies {
     implementation (project(':dev.galasa.extensions.common'))
 
     testImplementation(project(':dev.galasa.extensions.mocks'))
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-        csv.required = true
-        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
-    }
 }
 
 // Note: These values are consumed by the parent build process

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3Store.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3Store.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.cps.etcd.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import javax.validation.constraints.NotNull;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.options.DeleteOption;
+
+/**
+ * Abstract class containing common methods used to interact with etcd, like getting, setting,
+ * and deleting properties.
+ */
+public abstract class Etcd3Store {
+
+    protected final Client client;
+    protected final KV kvClient;
+
+    public Etcd3Store(Client client) {
+        this.client = client;
+        this.kvClient = client.getKVClient();
+    }
+
+    public Etcd3Store(URI etcdUri) {
+        this(Client.builder().endpoints(etcdUri).build());
+    }
+
+    protected String get(String key) throws InterruptedException, ExecutionException {
+        ByteSequence bsKey = ByteSequence.from(key, UTF_8);
+        CompletableFuture<GetResponse> getFuture = kvClient.get(bsKey);
+        GetResponse response = getFuture.get();
+        List<KeyValue> kvs = response.getKvs();
+
+        String retrievedKey = null;
+        if (!kvs.isEmpty()) {
+            retrievedKey = kvs.get(0).getValue().toString(UTF_8);
+        }
+        return retrievedKey;
+    }
+
+    protected void put(String key, String value) throws InterruptedException, ExecutionException {
+        ByteSequence bytesKey = ByteSequence.from(key, UTF_8);
+        ByteSequence bytesValue = ByteSequence.from(value, UTF_8);
+        kvClient.put(bytesKey, bytesValue).get();
+    }
+
+    protected void delete(@NotNull String key) throws InterruptedException, ExecutionException {
+        ByteSequence bytesKey = ByteSequence.from(key, StandardCharsets.UTF_8);
+        kvClient.delete(bytesKey).get();
+    }
+
+    protected void deletePrefix(@NotNull String keyPrefix) throws InterruptedException, ExecutionException {
+        ByteSequence bsKey = ByteSequence.from(keyPrefix, UTF_8);
+        DeleteOption options = DeleteOption.newBuilder().isPrefix(true).build();
+        kvClient.delete(bsKey, options).get();
+    }
+
+    protected void shutdownStore() {
+        kvClient.close();
+        client.close();
+    }
+}

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3CredentialsStoreTest.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/Etcd3CredentialsStoreTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.etcd.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import dev.galasa.cps.etcd.internal.Etcd3CredentialsStore;
+import dev.galasa.etcd.internal.mocks.MockEncryptionService;
+import dev.galasa.etcd.internal.mocks.MockEtcdClient;
+import dev.galasa.framework.spi.creds.CredentialsToken;
+import dev.galasa.framework.spi.creds.CredentialsUsername;
+import dev.galasa.framework.spi.creds.CredentialsUsernamePassword;
+import dev.galasa.framework.spi.creds.CredentialsUsernameToken;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class Etcd3CredentialsStoreTest {
+
+    @Test
+    public void testGetUsernameCredentialsReturnsCredentialsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String username = "my-user";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        mockCreds.put("secure.credentials." + credsId + ".username", username);
+
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        // When...
+        CredentialsUsername creds = (CredentialsUsername) store.getCredentials(credsId);
+
+        // Then...
+        assertThat(creds).isNotNull();
+        assertThat(creds.getUsername()).isEqualTo(username);
+    }
+
+    @Test
+    public void testGetUsernamePasswordCredentialsReturnsCredentialsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String username = "my-user";
+        String password = "not-a-password";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        mockCreds.put("secure.credentials." + credsId + ".username", username);
+        mockCreds.put("secure.credentials." + credsId + ".password", password);
+
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        // When...
+        CredentialsUsernamePassword creds = (CredentialsUsernamePassword) store.getCredentials(credsId);
+
+        // Then...
+        assertThat(creds).isNotNull();
+        assertThat(creds.getUsername()).isEqualTo(username);
+        assertThat(creds.getPassword()).isEqualTo(password);
+    }
+
+    @Test
+    public void testGetUsernameTokenCredentialsReturnsCredentialsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String username = "my-user";
+        String token = "a-token";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        mockCreds.put("secure.credentials." + credsId + ".username", username);
+        mockCreds.put("secure.credentials." + credsId + ".token", token);
+
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        // When...
+        CredentialsUsernameToken creds = (CredentialsUsernameToken) store.getCredentials(credsId);
+
+        // Then...
+        assertThat(creds).isNotNull();
+        assertThat(creds.getUsername()).isEqualTo(username);
+        assertThat(creds.getToken()).isEqualTo(token.getBytes());
+    }
+
+    @Test
+    public void testGetTokenCredentialsReturnsCredentialsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String token = "a-token";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        mockCreds.put("secure.credentials." + credsId + ".token", token);
+
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        // When...
+        CredentialsToken creds = (CredentialsToken) store.getCredentials(credsId);
+
+        // Then...
+        assertThat(creds).isNotNull();
+        assertThat(creds.getToken()).isEqualTo(token.getBytes());
+    }
+
+    @Test
+    public void testSetUsernameCredentialsSetsCredentialsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String username = "a-username";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        CredentialsUsername mockUsernameCreds = new CredentialsUsername(username);
+
+        // When...
+        store.setCredentials(credsId, mockUsernameCreds);
+
+        // Then...
+        assertThat(mockCreds).hasSize(1);
+        assertThat(mockCreds.get("secure.credentials." + credsId + ".username")).isEqualTo(username);
+        
+        // The credentials should have been encrypted when being set
+        assertThat(mockEncryptionService.getEncryptCount()).isEqualTo(1);
+        assertThat(mockEncryptionService.getDecryptCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testSetUsernamePasswordCredentialsSetsCredentialsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String username = "a-username";
+        String password = "not-a-password";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        CredentialsUsernamePassword mockUsernamePasswordCreds = new CredentialsUsernamePassword(username, password);
+
+        // When...
+        store.setCredentials(credsId, mockUsernamePasswordCreds);
+
+        // Then...
+        assertThat(mockCreds).hasSize(2);
+        assertThat(mockCreds.get("secure.credentials." + credsId + ".username")).isEqualTo(username);
+        assertThat(mockCreds.get("secure.credentials." + credsId + ".password")).isEqualTo(password);
+        
+        // The credentials should have been encrypted when being set
+        assertThat(mockEncryptionService.getEncryptCount()).isEqualTo(2);
+        assertThat(mockEncryptionService.getDecryptCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testSetUsernameTokenCredentialsSetsCredentialsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String username = "a-username";
+        String token = "a-token";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        CredentialsUsernameToken mockUsernameTokenCreds = new CredentialsUsernameToken(username, token);
+
+        // When...
+        store.setCredentials(credsId, mockUsernameTokenCreds);
+
+        // Then...
+        assertThat(mockCreds).hasSize(2);
+        assertThat(mockCreds.get("secure.credentials." + credsId + ".username")).isEqualTo(username);
+        assertThat(mockCreds.get("secure.credentials." + credsId + ".token")).isEqualTo(token);
+        
+        // The credentials should have been encrypted when being set
+        assertThat(mockEncryptionService.getEncryptCount()).isEqualTo(2);
+        assertThat(mockEncryptionService.getDecryptCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testSetTokenCredentialsSetsCredentialsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String token = "a-token";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        CredentialsToken mockTokenCreds = new CredentialsToken(token);
+
+        // When...
+        store.setCredentials(credsId, mockTokenCreds);
+
+        // Then...
+        assertThat(mockCreds).hasSize(1);
+        assertThat(mockCreds.get("secure.credentials." + credsId + ".token")).isEqualTo(token);
+        
+        // The credentials should have been encrypted when being set
+        assertThat(mockEncryptionService.getEncryptCount()).isEqualTo(1);
+        assertThat(mockEncryptionService.getDecryptCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testDeleteCredentialsRemovesCredentialsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String username = "a-username";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        mockCreds.put("secure.credentials." + credsId + ".username", username);
+
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        // When...
+        assertThat(mockCreds).hasSize(1);
+        store.deleteCredentials(credsId);
+
+        // Then...
+        assertThat(mockCreds).hasSize(0);
+    }
+
+    @Test
+    public void testDeleteCredentialsRemovesCredentialsByPrefix() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        String credsId = "CRED1";
+        String username = "a-username";
+        String password = "not-a-password";
+        
+        Map<String, String> mockCreds = new HashMap<>();
+        mockCreds.put("secure.credentials." + credsId + ".username", username);
+        mockCreds.put("secure.credentials." + credsId + ".password", password);
+
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        // When...
+        assertThat(mockCreds).hasSize(2);
+        store.deleteCredentials(credsId);
+
+        // Then...
+        assertThat(mockCreds).hasSize(0);
+    }
+
+    @Test
+    public void testShutdownClosesEtcdClientsOk() throws Exception {
+        // Given...
+        MockEncryptionService mockEncryptionService = new MockEncryptionService();
+        Map<String, String> mockCreds = new HashMap<>();
+
+        MockEtcdClient mockClient = new MockEtcdClient(mockCreds);
+        Etcd3CredentialsStore store = new Etcd3CredentialsStore(null, mockEncryptionService, mockClient);
+
+        // When...
+        store.shutdown();
+
+        // Then...
+        assertThat(mockClient.isClientShutDown()).isTrue();
+    }
+}

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEncryptionService.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEncryptionService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.etcd.internal.mocks;
+
+import dev.galasa.framework.spi.creds.CredentialsException;
+import dev.galasa.framework.spi.creds.IEncryptionService;
+
+public class MockEncryptionService implements IEncryptionService {
+
+    private int encryptCount = 0;
+    private int decryptCount = 0;
+
+    public int getEncryptCount() {
+        return encryptCount;
+    }
+
+    public int getDecryptCount() {
+        return decryptCount;
+    }
+
+    @Override
+    public String encrypt(String plainText) throws CredentialsException {
+        encryptCount++;
+        return plainText;
+    }
+
+    @Override
+    public String decrypt(String encryptedText) throws CredentialsException {
+        decryptCount++;
+        return encryptedText;
+    }
+}

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdClient.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdClient.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.etcd.internal.mocks;
+
+import java.util.Map;
+
+import io.etcd.jetcd.Auth;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.Cluster;
+import io.etcd.jetcd.Election;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.Lease;
+import io.etcd.jetcd.Lock;
+import io.etcd.jetcd.Maintenance;
+import io.etcd.jetcd.Watch;
+
+public class MockEtcdClient implements Client {
+
+    private KV kvClient;
+    private boolean isClientShutDown = false;
+
+    public MockEtcdClient(Map<String, String> kvContents) {
+        this.kvClient = new MockEtcdKvClient(kvContents);
+    }
+
+    @Override
+    public KV getKVClient() {
+        return kvClient;
+    }
+
+    @Override
+    public void close() {
+        isClientShutDown = true;
+    }
+
+    public boolean isClientShutDown() {
+        return isClientShutDown;
+    }
+
+    @Override
+    public Auth getAuthClient() {
+        throw new UnsupportedOperationException("Unimplemented method 'getAuthClient'");
+    }
+
+    @Override
+    public Cluster getClusterClient() {
+        throw new UnsupportedOperationException("Unimplemented method 'getClusterClient'");
+    }
+
+    @Override
+    public Election getElectionClient() {
+        throw new UnsupportedOperationException("Unimplemented method 'getElectionClient'");
+    }
+
+    @Override
+    public Lease getLeaseClient() {
+        throw new UnsupportedOperationException("Unimplemented method 'getLeaseClient'");
+    }
+
+    @Override
+    public Lock getLockClient() {
+        throw new UnsupportedOperationException("Unimplemented method 'getLockClient'");
+    }
+
+    @Override
+    public Maintenance getMaintenanceClient() {
+        throw new UnsupportedOperationException("Unimplemented method 'getMaintenanceClient'");
+    }
+
+    @Override
+    public Watch getWatchClient() {
+        throw new UnsupportedOperationException("Unimplemented method 'getWatchClient'");
+    }
+    
+}

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdKvClient.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/test/java/dev/galasa/etcd/internal/mocks/MockEtcdKvClient.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.etcd.internal.mocks;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.protobuf.ByteString;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.Txn;
+import io.etcd.jetcd.api.KeyValue;
+import io.etcd.jetcd.api.KeyValue.Builder;
+import io.etcd.jetcd.api.RangeResponse;
+import io.etcd.jetcd.kv.CompactResponse;
+import io.etcd.jetcd.kv.DeleteResponse;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.kv.PutResponse;
+import io.etcd.jetcd.options.CompactOption;
+import io.etcd.jetcd.options.DeleteOption;
+import io.etcd.jetcd.options.GetOption;
+import io.etcd.jetcd.options.PutOption;
+
+public class MockEtcdKvClient implements KV {
+
+    Map<String, String> kvContents = new HashMap<>();
+
+    public MockEtcdKvClient(Map<String, String> kvContents) {
+        this.kvContents = kvContents;
+    }
+
+    @Override
+    public CompletableFuture<GetResponse> get(ByteSequence key) {
+        String keyStr = key.toString();
+        String value = kvContents.get(keyStr);
+
+        RangeResponse rangeResponse;
+        if (value == null) {
+            rangeResponse = RangeResponse.newBuilder().build();
+        } else {
+            ByteString keyByteStr = ByteString.copyFromUtf8(keyStr);
+            Builder builder = KeyValue.newBuilder().setKey(keyByteStr);
+            ByteString valueByteStr = ByteString.copyFromUtf8(value);
+            builder = builder.setValue(valueByteStr);
+            KeyValue kv = builder.build();
+            rangeResponse = RangeResponse.newBuilder().addKvs(kv).build();
+        }
+        GetResponse mockResponse = new GetResponse(rangeResponse, key);
+        return CompletableFuture.completedFuture(mockResponse);
+    }
+
+    @Override
+    public CompletableFuture<PutResponse> put(ByteSequence key, ByteSequence value) {
+        String keyStr = key.toString();
+        String valueStr = value.toString();
+        kvContents.put(keyStr, valueStr);
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+
+    @Override
+    public CompletableFuture<DeleteResponse> delete(ByteSequence key, DeleteOption options) {
+        String keyStr = key.toString();
+
+        if (options.isPrefix()) {
+            Set<String> keysToRemove = new HashSet<>();
+            Set<String> existingKeySet = kvContents.keySet();
+
+            for (String existingKey : existingKeySet) {
+                if (existingKey.startsWith(keyStr)) {
+                    keysToRemove.add(existingKey);
+                }
+            }
+
+            existingKeySet.removeAll(keysToRemove);
+        } else {
+            kvContents.remove(keyStr);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<CompactResponse> compact(long key) {
+        throw new UnsupportedOperationException("Unimplemented method 'compact'");
+    }
+
+    @Override
+    public CompletableFuture<CompactResponse> compact(long key, CompactOption options) {
+        throw new UnsupportedOperationException("Unimplemented method 'compact'");
+    }
+
+    @Override
+    public CompletableFuture<DeleteResponse> delete(ByteSequence key) {
+        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+    }
+
+    @Override
+    public CompletableFuture<GetResponse> get(ByteSequence key, GetOption options) {
+        throw new UnsupportedOperationException("Unimplemented method 'get'");
+    }
+
+    @Override
+    public CompletableFuture<PutResponse> put(ByteSequence key, ByteSequence value, PutOption options) {
+        throw new UnsupportedOperationException("Unimplemented method 'put'");
+    }
+
+    @Override
+    public Txn txn() {
+        throw new UnsupportedOperationException("Unimplemented method 'txn'");
+    }
+    
+}

--- a/galasa-extensions-parent/dev.galasa.events.kafka/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.events.kafka/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'biz.aQute.bnd.builder'
     id 'galasa.extensions'
-    id 'jacoco'
 }
 
 description = 'Galasa Events Plug-In - Kafka'
@@ -12,14 +11,6 @@ dependencies {
     implementation 'dev.galasa:kafka.clients:3.7.0'
 
     testImplementation(project(':dev.galasa.extensions.mocks'))
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-        csv.required = true
-        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
-    }
 }
 
 // Note: These values are consumed by the parent build process

--- a/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
+++ b/galasa-extensions-parent/dev.galasa.ras.couchdb/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'biz.aQute.bnd.builder'
     id 'galasa.extensions'
-    id 'jacoco'
 }
 
 description = 'Galasa RAS - CouchDB'
@@ -19,14 +18,6 @@ dependencies {
     implementation (project(':dev.galasa.extensions.common'))
 
     testImplementation(project(':dev.galasa.extensions.mocks'))
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-        csv.required = true
-        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
-    }
 }
 
 // Note: These values are consumed by the parent build process


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1467

Related to changes in https://github.com/galasa-dev/framework/pull/658

## Changes
- Implemented the new `setCredentials` and `deleteCredentials` methods on the `ICredentialsStore` interface
  - Credentials are encrypted before being stored in etcd
- Refactored common etcd-related interactions like getting and deleting properties into a parent Etcd3Store class
- Moved jacoco test report generation to the galasa.extensions buildSrc plugin so that all extensions get jacoco reports during builds