### PR TITLE
Implemented getAllCredentials method for etcd credentials store

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -81,7 +81,7 @@
         "hashed_secret": "1beb7496ebbe82c61151be093956d83dac625c13",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 430,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -81,7 +81,7 @@
         "hashed_secret": "1beb7496ebbe82c61151be093956d83dac625c13",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 246,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3CredentialsStore.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3CredentialsStore.java
@@ -120,6 +120,9 @@ public class Etcd3CredentialsStore extends Etcd3Store implements ICredentialsSto
         Properties credentialProperties = credentials.toProperties(credentialsId);
 
         try {
+            // Clear any existing properties with the same credentials ID
+            deleteCredentials(credentialsId);
+
             for (Entry<Object, Object> property : credentialProperties.entrySet()) {
                 put((String) property.getKey(), encryptionService.encrypt((String) property.getValue()));
             }

--- a/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3Store.java
+++ b/galasa-extensions-parent/dev.galasa.cps.etcd/src/main/java/dev/galasa/cps/etcd/internal/Etcd3Store.java
@@ -9,7 +9,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -21,6 +23,7 @@ import io.etcd.jetcd.KV;
 import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.options.DeleteOption;
+import io.etcd.jetcd.options.GetOption;
 
 /**
  * Abstract class containing common methods used to interact with etcd, like getting, setting,
@@ -51,6 +54,28 @@ public abstract class Etcd3Store {
             retrievedKey = kvs.get(0).getValue().toString(UTF_8);
         }
         return retrievedKey;
+    }
+
+    protected Map<String, String> getPrefix(String keyPrefix) throws InterruptedException, ExecutionException {
+        Map<String, String> keyValues = new HashMap<>();
+
+        ByteSequence bsPrefix = ByteSequence.from(keyPrefix, UTF_8);
+        GetOption options = GetOption.newBuilder().isPrefix(true).build();
+        CompletableFuture<GetResponse> getFuture = kvClient.get(bsPrefix, options);
+
+        GetResponse response = getFuture.get();
+        List<KeyValue> kvs = response.getKvs();
+
+        for (KeyValue kv : kvs) {
+            // jetcd's getKey() method strips off the given prefix from matching keys, so add them back in
+            String key = kv.getKey().toString(UTF_8);
+            if (!key.startsWith(keyPrefix)) {
+                key = keyPrefix + key;
+            }
+            keyValues.put(key, kv.getValue().toString(UTF_8));
+        }
+
+        return keyValues;
     }
 
     protected void put(String key, String value) throws InterruptedException, ExecutionException {


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1467

## Changes
- Added `getAllCredentials()` implementation to get all credentials in the `secure` namespace from etcd

**Note: Builds for this PR will fail until https://github.com/galasa-dev/framework/pull/662 is delivered**